### PR TITLE
Pack NuGet on Windows to include Windows TFMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet pack ci.slnf -c Release --no-build -o ./artifacts
 
       - name: Upload NuGet packages
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
           name: nuget-packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
 
   publish:
     needs: build-and-test
-    runs-on: macos-latest
+    runs-on: windows-latest
     permissions:
       contents: read
       packages: write
@@ -54,6 +54,7 @@ jobs:
 
       - name: Determine version
         id: version
+        shell: bash
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           # Strip leading 'v' if present (e.g., v1.2.3 -> 1.2.3)


### PR DESCRIPTION
The publish job ran on `macos-latest` which skips the Windows target framework (`net10.0-windows10.0.19041.0`) since it's gated by `IsOSPlatform('windows')` in the csproj files.

Switch the publish job to `windows-latest` so `dotnet pack` includes all four TFMs (android, ios, maccatalyst, **windows**) in the NuGet packages.

Also switches the CI artifact upload from macos to windows for consistency.