### PR TITLE
Fix property command for compound types + add dot-path notation

### DIFF
--- a/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
@@ -307,16 +307,86 @@ public class DevFlowAgentService : IDisposable
 
         var value = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(id, _app);            if (el == null) return (object?)null;
+            var el = _treeWalker.GetElementById(id, _app);
+            if (el == null) return (object?)null;
 
-            var type = el.GetType();
-            var prop = type.GetProperty(propName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.IgnoreCase);
-            return prop?.GetValue(el)?.ToString();
+            // Support dot-path notation (e.g., "Shadow.Radius")
+            var parts = propName.Split('.');
+            object? current = el;
+            PropertyInfo? prop = null;
+            foreach (var part in parts)
+            {
+                if (current == null) return null;
+                var type = current.GetType();
+                prop = type.GetProperty(part, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (prop == null) return null;
+                current = prop.GetValue(current);
+            }
+            return FormatPropertyValue(current);
         });
 
         return value != null
             ? HttpResponse.Json(new { id, property = propName, value })
             : HttpResponse.NotFound($"Property '{propName}' not found on element '{id}'");
+    }
+
+    private static string? FormatPropertyValue(object? value)
+    {
+        if (value == null) return null;
+        if (value is string s) return s;
+
+        // Try TypeConverter first — handles Thickness, CornerRadius, Color, enums, etc.
+        var converter = System.ComponentModel.TypeDescriptor.GetConverter(value.GetType());
+        if (converter.CanConvertTo(typeof(string))
+            && converter.GetType() != typeof(System.ComponentModel.TypeConverter)
+            && converter is not System.ComponentModel.CollectionConverter)
+        {
+            try
+            {
+                var result = converter.ConvertToString(value);
+                if (result != null) return result;
+            }
+            catch { }
+        }
+
+        // Fallback for complex types that lack TypeConverter ConvertTo support
+        return value switch
+        {
+            Shadow shadow => FormatShadow(shadow),
+            SolidColorBrush scb => $"SolidColorBrush Color={scb.Color?.ToArgbHex() ?? "(null)"}",
+            LinearGradientBrush lgb => $"LinearGradientBrush StartPoint={lgb.StartPoint}, EndPoint={lgb.EndPoint}, Stops={lgb.GradientStops?.Count ?? 0}",
+            RadialGradientBrush rgb => $"RadialGradientBrush Center={rgb.Center}, Radius={rgb.Radius}, Stops={rgb.GradientStops?.Count ?? 0}",
+            Brush brush => brush.GetType().Name,
+            Microsoft.Maui.Controls.Shapes.RoundRectangle rr => $"RoundRectangle CornerRadius={FormatPropertyValue(rr.CornerRadius)}",
+            Microsoft.Maui.Controls.Shapes.Shape shape => shape.GetType().Name,
+            ColumnDefinitionCollection cols => string.Join(", ", cols.Select(c => FormatGridLength(c.Width))),
+            RowDefinitionCollection rows => string.Join(", ", rows.Select(r => FormatGridLength(r.Height))),
+            FileImageSource fis => $"File: {fis.File}",
+            UriImageSource uis => $"Uri: {uis.Uri}",
+            FontImageSource fontIs => $"Font: {fontIs.Glyph} ({fontIs.FontFamily})",
+            ImageSource img => img.GetType().Name,
+            System.Collections.ICollection col => $"{col.GetType().Name} ({col.Count} items)",
+            IFormattable f => f.ToString(null, System.Globalization.CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? value.GetType().Name,
+        };
+    }
+
+    private static string FormatGridLength(GridLength gl) => gl.IsStar
+        ? (gl.Value == 1 ? "*" : $"{gl.Value}*")
+        : gl.IsAbsolute ? gl.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        : "Auto";
+
+    private static string FormatShadow(Shadow shadow)
+    {
+        var parts = new List<string>();
+        if (shadow.Brush is SolidColorBrush scb)
+            parts.Add($"Brush={scb.Color?.ToArgbHex()}");
+        else if (shadow.Brush != null)
+            parts.Add($"Brush={shadow.Brush.GetType().Name}");
+        parts.Add($"Offset=({shadow.Offset.X},{shadow.Offset.Y})");
+        parts.Add($"Radius={shadow.Radius}");
+        parts.Add($"Opacity={shadow.Opacity}");
+        return string.Join(", ", parts);
     }
 
     private async Task<HttpResponse> HandleSetProperty(HttpRequest request)


### PR DESCRIPTION
Fixes #10

## Problem

`maui-devflow MAUI property <id> <prop>` returned the .NET type name for compound property types:

```
$ maui-devflow MAUI property AddTodoBorder Padding
Padding: Microsoft.Maui.Thickness

$ maui-devflow MAUI property AddTodoBorder Stroke
Stroke: Microsoft.Maui.Controls.SolidColorBrush
```

## Fix

Added a `FormatPropertyValue` method that renders compound types with readable sub-property values, and dot-path notation for nested property access.

### Before → After

| Property | Before | After |
|---|---|---|
| Padding | `Microsoft.Maui.Thickness` | `Left=12, Top=12, Right=12, Bottom=12` |
| Stroke | `Microsoft.Maui.Controls.SolidColorBrush` | `SolidColorBrush Color=#E0E0E0` |
| StrokeShape | `Microsoft.Maui.Controls.Shapes.RoundRectangle` | `RoundRectangle CornerRadius=TopLeft=12, ...` |
| Shadow | `Microsoft.Maui.Controls.Shadow` | `Brush=#6F42C1, Offset=(0,0), Radius=8, Opacity=0.6` |

### Dot-path notation (new)

Navigate into nested properties:

```bash
maui-devflow MAUI property <id> Padding.Left     # → 12
maui-devflow MAUI property <id> Shadow.Radius     # → 8
maui-devflow MAUI property <id> StrokeShape.CornerRadius  # → TopLeft=6, ...
```

### Supported compound types

- `Thickness` — Left, Top, Right, Bottom
- `Shadow` — Brush, Offset, Radius, Opacity
- `SolidColorBrush` — Color hex
- `LinearGradientBrush` — StartPoint, EndPoint, Stops count
- `RadialGradientBrush` — Center, Radius, Stops count
- `RoundRectangle` — CornerRadius
- `CornerRadius` — TopLeft, TopRight, BottomLeft, BottomRight
- `Color` — ARGB hex
- Other `IFormattable` — uses InvariantCulture formatting
- Fallback — `.ToString()`

## Testing

E2E verified on Mac Catalyst against running SampleMauiApp.