### PR TITLE
Fix macOS modal sheet screenshot capture

### DIFF
--- a/src/MauiDevFlow.Agent/DevFlowAgentService.cs
+++ b/src/MauiDevFlow.Agent/DevFlowAgentService.cs
@@ -67,6 +67,10 @@ public class PlatformAgentService : DevFlowAgentService
                     window = nsWindow;
             }
 
+            // If a modal sheet is attached, capture it instead of the main window
+            if (window?.AttachedSheet is NSWindow sheet)
+                window = sheet;
+
             // Use CGWindowListCreateImage for composited capture including layer-backed controls
             if (window != null)
             {

--- a/src/SampleMauiApp.Linux/SampleMauiApp.Linux.csproj
+++ b/src/SampleMauiApp.Linux/SampleMauiApp.Linux.csproj
@@ -29,6 +29,7 @@
     <Compile Include="..\SampleMauiApp\BlazorTodoPage.xaml.cs" Link="BlazorTodoPage.xaml.cs" />
     <Compile Include="..\SampleMauiApp\DialogTestPage.xaml.cs" Link="DialogTestPage.xaml.cs" />
     <Compile Include="..\SampleMauiApp\InteractionTestPage.xaml.cs" Link="InteractionTestPage.xaml.cs" />
+    <Compile Include="..\SampleMauiApp\ModalTestPage.xaml.cs" Link="ModalTestPage.xaml.cs" />
     <Compile Include="..\SampleMauiApp\TodoService.cs" Link="TodoService.cs" />
     <Compile Include="..\SampleMauiApp\TodoItem.cs" Link="TodoItem.cs" />
     <Compile Include="..\SampleMauiApp\DebugFileLogger.cs" Link="DebugFileLogger.cs" />
@@ -42,6 +43,7 @@
     <MauiXaml Include="..\SampleMauiApp\BlazorTodoPage.xaml" Link="BlazorTodoPage.xaml" />
     <MauiXaml Include="..\SampleMauiApp\DialogTestPage.xaml" Link="DialogTestPage.xaml" />
     <MauiXaml Include="..\SampleMauiApp\InteractionTestPage.xaml" Link="InteractionTestPage.xaml" />
+    <MauiXaml Include="..\SampleMauiApp\ModalTestPage.xaml" Link="ModalTestPage.xaml" />
   </ItemGroup>
 
   <!-- Resources are symlinked from SampleMauiApp -->

--- a/src/SampleMauiApp.MacOS/SampleMauiApp.MacOS.csproj
+++ b/src/SampleMauiApp.MacOS/SampleMauiApp.MacOS.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Platform.Maui.MacOS" Version="0.2.0-beta.2" />
-    <PackageReference Include="Platform.Maui.MacOS.BlazorWebView" Version="0.2.0-beta.2" />
-    <PackageReference Include="Platform.Maui.Essentials.MacOS" Version="0.2.0-beta.2" />
+    <PackageReference Include="Platform.Maui.MacOS" Version="0.2.0-beta.19" />
+    <PackageReference Include="Platform.Maui.MacOS.BlazorWebView" Version="0.2.0-beta.19" />
+    <PackageReference Include="Platform.Maui.MacOS.Essentials" Version="0.2.0-beta.19" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
@@ -35,6 +35,7 @@
     <Compile Include="..\SampleMauiApp\BlazorTodoPage.xaml.cs" Link="BlazorTodoPage.xaml.cs" />
     <Compile Include="..\SampleMauiApp\DialogTestPage.xaml.cs" Link="DialogTestPage.xaml.cs" />
     <Compile Include="..\SampleMauiApp\InteractionTestPage.xaml.cs" Link="InteractionTestPage.xaml.cs" />
+    <Compile Include="..\SampleMauiApp\ModalTestPage.xaml.cs" Link="ModalTestPage.xaml.cs" />
     <Compile Include="..\SampleMauiApp\TodoService.cs" Link="TodoService.cs" />
     <Compile Include="..\SampleMauiApp\TodoItem.cs" Link="TodoItem.cs" />
     <Compile Include="..\SampleMauiApp\DebugFileLogger.cs" Link="DebugFileLogger.cs" />
@@ -48,6 +49,7 @@
     <MauiXaml Include="..\SampleMauiApp\BlazorTodoPage.xaml" Link="BlazorTodoPage.xaml" />
     <MauiXaml Include="..\SampleMauiApp\DialogTestPage.xaml" Link="DialogTestPage.xaml" />
     <MauiXaml Include="..\SampleMauiApp\InteractionTestPage.xaml" Link="InteractionTestPage.xaml" />
+    <MauiXaml Include="..\SampleMauiApp\ModalTestPage.xaml" Link="ModalTestPage.xaml" />
   </ItemGroup>
 
   <!-- Resources -->

--- a/src/SampleMauiApp/MainPage.xaml
+++ b/src/SampleMauiApp/MainPage.xaml
@@ -11,14 +11,31 @@
 
         <!-- Header -->
         <VerticalStackLayout Grid.Row="0" Spacing="4" Padding="0,8,0,16">
-            <Label Text="📝 My Todos"
-                   FontSize="28"
-                   FontAttributes="Bold"
-                   AutomationId="HeaderLabel">
-                <Label.TextColor>
-                    <AppThemeBinding Light="#1C1B1F" Dark="#E6E1E5" />
-                </Label.TextColor>
-            </Label>
+            <Grid ColumnDefinitions="*,Auto">
+                <Label Text="📝 My Todos"
+                       FontSize="28"
+                       FontAttributes="Bold"
+                       AutomationId="HeaderLabel">
+                    <Label.TextColor>
+                        <AppThemeBinding Light="#1C1B1F" Dark="#E6E1E5" />
+                    </Label.TextColor>
+                </Label>
+                <Button Grid.Column="1"
+                        Text="Show Modal"
+                        FontSize="12"
+                        CornerRadius="8"
+                        Padding="12,4"
+                        VerticalOptions="Center"
+                        AutomationId="ShowModalButton"
+                        Clicked="OnShowModal">
+                    <Button.BackgroundColor>
+                        <AppThemeBinding Light="#6750A4" Dark="#D0BCFF" />
+                    </Button.BackgroundColor>
+                    <Button.TextColor>
+                        <AppThemeBinding Light="#FFFFFF" Dark="#381E72" />
+                    </Button.TextColor>
+                </Button>
+            </Grid>
             <Label x:Name="CountLabel"
                    Text="0 items"
                    FontSize="14"

--- a/src/SampleMauiApp/MainPage.xaml.cs
+++ b/src/SampleMauiApp/MainPage.xaml.cs
@@ -107,6 +107,11 @@ public partial class MainPage : ContentPage
         });
     }
 
+    private async void OnShowModal(object? sender, EventArgs e)
+    {
+        await Navigation.PushModalAsync(new ModalTestPage());
+    }
+
     private void OnAddTodo(object? sender, EventArgs e)
     {
         var text = NewTodoEntry.Text?.Trim();

--- a/src/SampleMauiApp/ModalTestPage.xaml
+++ b/src/SampleMauiApp/ModalTestPage.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="SampleMauiApp.ModalTestPage"
+             Title="Modal Page"
+             AutomationId="ModalTestPage">
+    <ContentPage.BackgroundColor>
+        <AppThemeBinding Light="#F5F5F5" Dark="#1C1B1F" />
+    </ContentPage.BackgroundColor>
+
+    <VerticalStackLayout Spacing="12" Padding="20" VerticalOptions="Center">
+        <Label Text="🔲 Modal Page"
+               FontSize="18"
+               FontAttributes="Bold"
+               HorizontalOptions="Center"
+               AutomationId="ModalTitle">
+            <Label.TextColor>
+                <AppThemeBinding Light="#1C1B1F" Dark="#E6E1E5" />
+            </Label.TextColor>
+        </Label>
+
+        <Label Text="This page was pushed modally."
+               FontSize="13"
+               HorizontalOptions="Center"
+               AutomationId="ModalDescription">
+            <Label.TextColor>
+                <AppThemeBinding Light="#49454F" Dark="#CAC4D0" />
+            </Label.TextColor>
+        </Label>
+
+        <Button Text="Close Modal"
+                FontSize="13"
+                CornerRadius="8"
+                Padding="16,8"
+                HorizontalOptions="Center"
+                AutomationId="CloseModalButton"
+                Clicked="OnCloseModal">
+            <Button.BackgroundColor>
+                <AppThemeBinding Light="#6750A4" Dark="#D0BCFF" />
+            </Button.BackgroundColor>
+            <Button.TextColor>
+                <AppThemeBinding Light="#FFFFFF" Dark="#381E72" />
+            </Button.TextColor>
+        </Button>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/SampleMauiApp/ModalTestPage.xaml.cs
+++ b/src/SampleMauiApp/ModalTestPage.xaml.cs
@@ -1,0 +1,21 @@
+#if MACOS
+using Microsoft.Maui.Platform.MacOS;
+#endif
+
+namespace SampleMauiApp;
+
+public partial class ModalTestPage : ContentPage
+{
+    public ModalTestPage()
+    {
+        InitializeComponent();
+#if MACOS
+        MacOSPage.SetModalSheetSizesToContent(this, true);
+#endif
+    }
+
+    private async void OnCloseModal(object? sender, EventArgs e)
+    {
+        await Navigation.PopModalAsync();
+    }
+}


### PR DESCRIPTION
## Problem

When a modal page is pushed via `PushModalAsync` on macOS (AppKit), the screenshot API captures only the dimmed main window — the modal sheet content is missing.

**Root cause:** On macOS, modal sheets render as a child `NSWindow` (`AttachedSheet`). The screenshot code used `CGWindowListCreateImage` on the main window, which only shows the dimmed background when a sheet is active.

## Fix

Check `window.AttachedSheet` before capturing. When a sheet is present, capture the sheet's `NSWindow` instead of the main window.

### Before
Main window captured — sheet content invisible.

### After  
Sheet content captured correctly.

## Other changes

- Add `ModalTestPage` to sample app with `MacOSPage.SetModalSheetSizesToContent`
- Add "Show Modal" button to MainPage for testing modal workflows
- Update `Platform.Maui.MacOS` packages from `0.2.0-beta.15` → `0.2.0-beta.19`  
- Add missing `NetworkTestPage` + `ModalTestPage` links to macOS and Linux projects
- Add `AddHttpClient()` and `NetworkTestPage` DI registration to macOS/Linux `MauiProgram.cs`