### PR TITLE
Fix GTK modal screenshots and update Linux GTK packages to 0.5.0

### DIFF
--- a/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
@@ -342,7 +342,37 @@ public class DevFlowAgentService : IDisposable
             var pngData = await DispatchAsync(async () =>
             {
                 var window = GetWindow(windowIndex);
-                if (window?.Page is not VisualElement rootElement) return null;
+                if (window == null) return null;
+
+                // If a modal page is displayed, capture it instead of the underlying page
+                VisualElement? topModal = null;
+                try
+                {
+                    var modalStack = window.Page?.Navigation?.ModalStack;
+                    if (modalStack?.Count > 0 && modalStack[^1] is VisualElement ms)
+                        topModal = ms;
+                }
+                catch { }
+
+                // Fallback: check Window's visual children for modal pages
+                // (on some platforms like GTK, modals appear as direct children of the Window)
+                if (topModal == null && window is IVisualTreeElement windowVte)
+                {
+                    var children = windowVte.GetVisualChildren();
+                    for (int i = children.Count - 1; i >= 0; i--)
+                    {
+                        if (children[i] is Page page && page != window.Page)
+                        {
+                            topModal = page;
+                            break;
+                        }
+                    }
+                }
+
+                if (topModal != null)
+                    return await CaptureScreenshotAsync(topModal);
+
+                if (window.Page is not VisualElement rootElement) return null;
 
                 return await CaptureScreenshotAsync(rootElement);
             });

--- a/src/MauiDevFlow.Agent.Gtk/GtkAgentService.cs
+++ b/src/MauiDevFlow.Agent.Gtk/GtkAgentService.cs
@@ -106,7 +106,18 @@ public class GtkAgentService : DevFlowAgentService
         }
         catch { }
 
-        // GTK4-specific fallback: capture via Gtk.WidgetPaintable
+        // GTK4-specific fallback: capture the rootElement's native widget directly
+        try
+        {
+            if (rootElement.Handler?.PlatformView is global::Gtk.Widget widget)
+            {
+                var pngBytes = CaptureGtkWidget(widget);
+                if (pngBytes != null) return pngBytes;
+            }
+        }
+        catch { }
+
+        // Final fallback: capture the main GTK window
         try
         {
             var window = Application.Current?.Windows.FirstOrDefault();

--- a/src/MauiDevFlow.Agent.Gtk/MauiDevFlow.Agent.Gtk.csproj
+++ b/src/MauiDevFlow.Agent.Gtk/MauiDevFlow.Agent.Gtk.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Platform.Maui.Linux.Gtk4" Version="0.2.3" />
+    <PackageReference Include="Platform.Maui.Linux.Gtk4" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MauiDevFlow.Blazor.Gtk/MauiDevFlow.Blazor.Gtk.csproj
+++ b/src/MauiDevFlow.Blazor.Gtk/MauiDevFlow.Blazor.Gtk.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Platform.Maui.Linux.Gtk4.BlazorWebView" Version="0.2.3" />
+    <PackageReference Include="Platform.Maui.Linux.Gtk4.BlazorWebView" Version="0.5.0" />
   </ItemGroup>
 
   <!-- Embed JS scripts as resources -->

--- a/src/SampleMauiApp.Linux/SampleMauiApp.Linux.csproj
+++ b/src/SampleMauiApp.Linux/SampleMauiApp.Linux.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Platform.Maui.Linux.Gtk4" Version="0.2.3" />
-    <PackageReference Include="Platform.Maui.Linux.Gtk4.BlazorWebView" Version="0.2.3" />
-    <PackageReference Include="Platform.Maui.Linux.Gtk4.Essentials" Version="0.2.3" />
+    <PackageReference Include="Platform.Maui.Linux.Gtk4" Version="0.5.0" />
+    <PackageReference Include="Platform.Maui.Linux.Gtk4.BlazorWebView" Version="0.5.0" />
+    <PackageReference Include="Platform.Maui.Linux.Gtk4.Essentials" Version="0.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Update Platform.Maui.Linux.Gtk4 packages from 0.2.3 to 0.5.0 (fixes modal native handlers)
- Default screenshot now detects modal pages via Navigation.ModalStack with fallback to scanning Window visual children (GTK modals appear as direct Window children)
- GtkAgentService.CaptureScreenshotAsync captures rootElement's native widget before falling back to main GTK window