### PR TITLE
feat: expose real version in agent status and CLI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Restore
         run: dotnet restore ci.slnf
 
-      - name: Build
-        run: dotnet build ci.slnf -c Release --no-restore
-
-      - name: Test
-        run: dotnet test ci.slnf -c Release --no-build --no-restore
-
       - name: Determine version
         id: version
         shell: bash
@@ -61,6 +55,12 @@ jobs:
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
+
+      - name: Build
+        run: dotnet build ci.slnf -c Release --no-restore -p:Version=${{ steps.version.outputs.version }}
+
+      - name: Test
+        run: dotnet test ci.slnf -c Release --no-build --no-restore
 
       - name: Pack
         run: dotnet pack ci.slnf -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}

--- a/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
@@ -283,7 +283,8 @@ public class DevFlowAgentService : IDisposable
             return new
             {
                 agent = "MauiDevFlow.Agent",
-                version = "1.0.0",
+                version = typeof(DevFlowAgentService).Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
                 platform = PlatformName,
                 deviceType = DeviceTypeName,
                 idiom = IdiomName,

--- a/src/MauiDevFlow.CLI/MauiDevFlow.CLI.csproj
+++ b/src/MauiDevFlow.CLI/MauiDevFlow.CLI.csproj
@@ -9,7 +9,6 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>maui-devflow</ToolCommandName>
     <PackageId>Redth.MauiDevFlow.CLI</PackageId>
-    <Version>0.13.0</Version>
     <Description>CDP-oriented CLI for automating MAUI Blazor WebViews</Description>
   </PropertyGroup>
 

--- a/src/MauiDevFlow.CLI/Program.cs
+++ b/src/MauiDevFlow.CLI/Program.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 
@@ -498,6 +499,19 @@ class Program
             await BatchAsync(host, port, delay, continueOnError, human),
             agentHostOption, agentPortOption, batchDelayOption, batchContinueOption, batchHumanOption);
         rootCommand.Add(batchCommand);
+
+        // ===== version command =====
+        var versionCmd = new Command("version", "Show CLI version information");
+        versionCmd.SetHandler(() =>
+        {
+            var asm = typeof(Program).Assembly;
+            var infoVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+            // Strip the +commitHash suffix if present (e.g. "0.13.0+abc123" → "0.13.0")
+            var plusIdx = infoVersion.IndexOf('+');
+            var version = plusIdx >= 0 ? infoVersion[..plusIdx] : infoVersion;
+            Console.WriteLine($"maui-devflow {version}");
+        });
+        rootCommand.Add(versionCmd);
 
         _parser = new CommandLineBuilder(rootCommand)
             .UseDefaults()


### PR DESCRIPTION
## Summary

The agent `/api/status` endpoint was hardcoded to return `version: "1.0.0"` and the CLI had no version command. This PR fixes both.

### Changes

- **Agent**: `/api/status` now returns the real `AssemblyInformationalVersion` (e.g. `0.13.0` or `0.14.0` when built via CI)
- **CLI**: New `maui-devflow version` command prints the CLI version
- **CLI csproj**: Removed duplicate `<Version>` — now inherits from `Directory.Build.props` (single source of truth)
- **publish.yml**: Moved version determination before build and passes `-p:Version=` to `dotnet build` so release assemblies have the correct version baked in

### Testing

- `maui-devflow version` → `maui-devflow 0.13.0`
- `curl localhost:10224/api/status` → `"version": "0.13.0+commitsha"` (dev), will be clean `"0.14.0"` in CI releases
- 94/94 tests pass