### PR TITLE
fix: serialize compound property types with full detail

### DIFF
--- a/.copilot/session-state/3c332596-d8b1-4e0c-bc20-ffe82d1234ac/plan.md
+++ b/.copilot/session-state/3c332596-d8b1-4e0c-bc20-ffe82d1234ac/plan.md
@@ -1,0 +1,18 @@
+# Plan: Fix compound property serialization (Issue #20)
+
+## Problem
+`FormatPropertyValue` in `DevFlowAgentService.cs` loses detail for compound MAUI types:
+- **Gradient brushes**: Only show stop count, not colors/offsets — clients can't reconstruct gradients
+- **LayoutOptions**: `ToString()` doesn't distinguish `Expands` flag  
+- **ItemsLayout**: `ToString()` loses orientation/spacing details
+
+## Approach
+Enhance `FormatPropertyValue` switch cases to serialize compound types with full detail. Keep the human-readable string format consistent with existing patterns.
+
+## Todos
+
+- [ ] fix-gradient-brushes — Enhance LinearGradientBrush and RadialGradientBrush to include gradient stop colors and offsets
+- [ ] add-layout-options — Add LayoutOptions formatting with Alignment + Expands  
+- [ ] add-items-layout — Add LinearItemsLayout and GridItemsLayout formatting
+- [ ] build-and-test — Build, run tests, verify with live app
+- [ ] create-pr — Create branch and PR for issue #20

--- a/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
@@ -581,13 +581,16 @@ public class DevFlowAgentService : IDisposable
         {
             Shadow shadow => FormatShadow(shadow),
             SolidColorBrush scb => $"SolidColorBrush Color={scb.Color?.ToArgbHex() ?? "(null)"}",
-            LinearGradientBrush lgb => $"LinearGradientBrush StartPoint={lgb.StartPoint}, EndPoint={lgb.EndPoint}, Stops={lgb.GradientStops?.Count ?? 0}",
-            RadialGradientBrush rgb => $"RadialGradientBrush Center={rgb.Center}, Radius={rgb.Radius}, Stops={rgb.GradientStops?.Count ?? 0}",
+            LinearGradientBrush lgb => $"LinearGradientBrush StartPoint={lgb.StartPoint}, EndPoint={lgb.EndPoint}, Stops=[{FormatGradientStops(lgb.GradientStops)}]",
+            RadialGradientBrush rgb => $"RadialGradientBrush Center={rgb.Center}, Radius={rgb.Radius}, Stops=[{FormatGradientStops(rgb.GradientStops)}]",
             Brush brush => brush.GetType().Name,
             Microsoft.Maui.Controls.Shapes.RoundRectangle rr => $"RoundRectangle CornerRadius={FormatPropertyValue(rr.CornerRadius)}",
             Microsoft.Maui.Controls.Shapes.Shape shape => shape.GetType().Name,
             ColumnDefinitionCollection cols => string.Join(", ", cols.Select(c => FormatGridLength(c.Width))),
             RowDefinitionCollection rows => string.Join(", ", rows.Select(r => FormatGridLength(r.Height))),
+            LayoutOptions lo => $"{lo.Alignment}{(lo.Expands ? ", Expands" : "")}",
+            LinearItemsLayout lin => $"LinearItemsLayout Orientation={lin.Orientation}, ItemSpacing={lin.ItemSpacing}",
+            GridItemsLayout grid => $"GridItemsLayout Span={grid.Span}, Orientation={grid.Orientation}, HorizontalSpacing={grid.HorizontalItemSpacing}, VerticalSpacing={grid.VerticalItemSpacing}",
             FileImageSource fis => $"File: {fis.File}",
             UriImageSource uis => $"Uri: {uis.Uri}",
             FontImageSource fontIs => $"Font: {fontIs.Glyph} ({fontIs.FontFamily})",
@@ -602,6 +605,13 @@ public class DevFlowAgentService : IDisposable
         ? (gl.Value == 1 ? "*" : $"{gl.Value}*")
         : gl.IsAbsolute ? gl.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
         : "Auto";
+
+    private static string FormatGradientStops(GradientStopCollection? stops)
+    {
+        if (stops == null || stops.Count == 0) return "";
+        return string.Join(", ", stops.Select(s =>
+            $"{s.Color.ToArgbHex()} {(s.Offset * 100).ToString("0", System.Globalization.CultureInfo.InvariantCulture)}%"));
+    }
 
     private static string FormatShadow(Shadow shadow)
     {


### PR DESCRIPTION
## Summary

Fixes #20 — gradient brushes now include stop colors and offsets in the property API response.

### Before
```
Background: LinearGradientBrush StartPoint={X=0 Y=1}, EndPoint={X=0 Y=0}, Stops=2
```

### After
```
Background: LinearGradientBrush StartPoint={X=0 Y=1}, EndPoint={X=0 Y=0}, Stops=[#FF0000 0%, #0000FF 100%]
```

### Changes

All in `FormatPropertyValue` (`DevFlowAgentService.cs`):

- **LinearGradientBrush** — serializes each gradient stop as `#RRGGBB NN%`
- **RadialGradientBrush** — same format, includes center + radius
- **LayoutOptions** — shows `Alignment` + `, Expands` flag when true
- **LinearItemsLayout** — shows `Orientation` + `ItemSpacing`
- **GridItemsLayout** — shows `Span`, `Orientation`, horizontal/vertical spacing

### Testing

Verified on Mac Catalyst:
- Linear gradient: `Stops=[#FF0000 0%, #0000FF 100%]` ✅
- Radial gradient with 3 stops: `Stops=[#FF6347 0%, #4169E1 50%, #32CD32 100%]` ✅
- LayoutOptions: `Fill` (no Expands suffix when false) ✅
- 94/94 tests pass