### PR TITLE
Add hit test API endpoint (fixes #23)

### DIFF
--- a/.claude/skills/maui-ai-debugging/SKILL.md
+++ b/.claude/skills/maui-ai-debugging/SKILL.md
@@ -305,6 +305,7 @@ or `maui-devflow --agent-port 10224 MAUI status` — both are valid.
 | `MAUI status [--window W]` | Agent connection status, platform, app name, window count |
 | `MAUI tree [--depth N] [--window W]` | Visual tree (IDs, types, text, bounds). Depth 0=unlimited. Window is 0-based index; omit for all windows |
 | `MAUI query --type T --automationId A --text T` | Find elements (any/all filters) |
+| `MAUI hittest <x> <y> [--window W]` | Find elements at a point (deepest first). Returns IDs, types, bounds |
 | `MAUI tap <elementId>` | Tap an element |
 | `MAUI fill <elementId> <text>` | Fill text into Entry/Editor |
 | `MAUI clear <elementId>` | Clear text from element |

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ auto-assigned by the broker (range 10223–10899), or configurable via `.mauidev
 | `/api/action/scroll` | POST | Scroll by delta or scroll element into view `{"elementId":"...","deltaX":0,"deltaY":200}` |
 | `/api/action/resize?window=W` | POST | Resize window `{"width":800,"height":600}` |
 | `/api/screenshot?window=W&id=ID&selector=SEL` | GET | PNG screenshot. Full window, or element by ID/selector |
+| `/api/hittest?x=X&y=Y&window=W` | GET | Find elements at a point (deepest first). Returns element IDs, types, bounds |
 | `/api/property/{id}/{name}` | GET | Get property value |
 | `/api/property/{id}/{name}` | POST | Set property `{"value":"..."}` |
 | `/api/logs?limit=N&skip=N&source=S` | GET | Application logs (source: `native`, `webview`, or omit for all) |

--- a/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
@@ -239,6 +239,7 @@ public class DevFlowAgentService : IDisposable
         _server.MapGet("/api/tree", HandleTree);
         _server.MapGet("/api/element/{id}", HandleElement);
         _server.MapGet("/api/query", HandleQuery);
+        _server.MapGet("/api/hittest", HandleHitTest);
         _server.MapGet("/api/screenshot", HandleScreenshot);
         _server.MapGet("/api/property/{id}/{name}", HandleProperty);
         _server.MapPost("/api/property/{id}/{name}", HandleSetProperty);
@@ -357,6 +358,57 @@ public class DevFlowAgentService : IDisposable
 
         var simpleResults = await DispatchAsync(() => _treeWalker.Query(_app, type, automationId, text));
         return HttpResponse.Json(simpleResults);
+    }
+
+    private async Task<HttpResponse> HandleHitTest(HttpRequest request)
+    {
+        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+
+        if (!request.QueryParams.TryGetValue("x", out var xStr) || !double.TryParse(xStr, out var x))
+            return HttpResponse.Error("x coordinate is required");
+        if (!request.QueryParams.TryGetValue("y", out var yStr) || !double.TryParse(yStr, out var y))
+            return HttpResponse.Error("y coordinate is required");
+
+        var windowIndex = ParseWindowIndex(request);
+
+        var result = await DispatchAsync(() =>
+        {
+            var window = GetWindow(windowIndex);
+            if (window == null) return (object?)null;
+
+            // Ensure tree is walked so element IDs are assigned
+            _treeWalker.WalkTree(_app!, 0, windowIndex);
+
+            var hits = VisualTreeElementExtensions.GetVisualTreeElements(window, x, y);
+            var elements = new List<object>();
+            foreach (var hit in hits)
+            {
+                if (hit is not IVisualTreeElement vte) continue;
+                var id = _treeWalker.GetIdForElement(vte);
+                if (id == null) continue;
+
+                var info = new Dictionary<string, object?> { ["id"] = id, ["type"] = hit.GetType().Name };
+                if (hit is VisualElement ve)
+                {
+                    info["automationId"] = ve.AutomationId;
+                    info["bounds"] = new BoundsInfo
+                    {
+                        X = double.IsFinite(ve.Frame.X) ? ve.Frame.X : 0,
+                        Y = double.IsFinite(ve.Frame.Y) ? ve.Frame.Y : 0,
+                        Width = double.IsFinite(ve.Frame.Width) ? ve.Frame.Width : 0,
+                        Height = double.IsFinite(ve.Frame.Height) ? ve.Frame.Height : 0
+                    };
+                }
+                if (hit is Label l) info["text"] = l.Text;
+                else if (hit is Button b) info["text"] = b.Text;
+                elements.Add(info);
+            }
+            return (object?)new { x, y, window = windowIndex ?? 0, elements };
+        });
+
+        return result != null
+            ? HttpResponse.Json(result)
+            : HttpResponse.Error($"Window {windowIndex ?? 0} not found");
     }
 
     protected virtual async Task<HttpResponse> HandleScreenshot(HttpRequest request)

--- a/src/MauiDevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/MauiDevFlow.Agent.Core/VisualTreeWalker.cs
@@ -65,6 +65,14 @@ public class VisualTreeWalker
     }
 
     /// <summary>
+    /// Reverse lookup: gets the ID for a previously-mapped visual tree element.
+    /// </summary>
+    public string? GetIdForElement(IVisualTreeElement element)
+    {
+        return _reverseMap.TryGetValue(element, out var id) ? id : null;
+    }
+
+    /// <summary>
     /// Walks the visual tree starting from the application's windows.
     /// When windowIndex is null, walks all windows. Otherwise walks only the specified window.
     /// </summary>

--- a/src/MauiDevFlow.CLI/Program.cs
+++ b/src/MauiDevFlow.CLI/Program.cs
@@ -181,6 +181,14 @@ class Program
             agentHostOption, agentPortOption, queryTypeOption, queryAutoIdOption, queryTextOption, querySelectorOption);
         mauiCommand.Add(mauiQueryCmd);
 
+        // MAUI hittest
+        var hitTestXArg = new Argument<double>("x", "X coordinate");
+        var hitTestYArg = new Argument<double>("y", "Y coordinate");
+        var mauiHitTestCmd = new Command("hittest", "Find elements at a point") { hitTestXArg, hitTestYArg, windowOption };
+        mauiHitTestCmd.SetHandler(async (host, port, x, y, window) => await MauiHitTestAsync(host, port, x, y, window),
+            agentHostOption, agentPortOption, hitTestXArg, hitTestYArg, windowOption);
+        mauiCommand.Add(mauiHitTestCmd);
+
         // MAUI tap
         var tapIdArg = new Argument<string>("elementId", "Element ID to tap");
         var mauiTapCmd = new Command("tap", "Tap element") { tapIdArg };
@@ -1190,6 +1198,17 @@ class Program
                     (el.IsVisible ? "" : " [hidden]") +
                     (el.IsEnabled ? "" : " [disabled]"));
             }
+        }
+        catch (Exception ex) { WriteError(ex.Message); }
+    }
+
+    private static async Task MauiHitTestAsync(string host, int port, double x, double y, int? window)
+    {
+        try
+        {
+            using var client = new MauiDevFlow.Driver.AgentClient(host, port);
+            var json = await client.HitTestAsync(x, y, window);
+            Console.WriteLine(json);
         }
         catch (Exception ex) { WriteError(ex.Message); }
     }

--- a/src/MauiDevFlow.Driver/AgentClient.cs
+++ b/src/MauiDevFlow.Driver/AgentClient.cs
@@ -193,6 +193,14 @@ public class AgentClient : IDisposable
         return await _http.GetStringAsync($"{_baseUrl}{path}");
     }
 
+    public async Task<string> HitTestAsync(double x, double y, int? window = null)
+    {
+        var path = $"/api/hittest?x={x}&y={y}";
+        if (window.HasValue)
+            path += $"&window={window.Value}";
+        return await _http.GetStringAsync($"{_baseUrl}{path}");
+    }
+
     private async Task<T?> GetAsync<T>(string path) where T : class
     {
         try


### PR DESCRIPTION
Adds a hit test API endpoint that returns all visual elements at a given (x, y) coordinate.

## Changes

- **`GET /api/hittest?x=X&y=Y&window=W`** — new endpoint using MAUI's `VisualTreeElementExtensions.GetVisualTreeElements` for platform-level hit testing
- Returns elements deepest-first with id, type, automationId, bounds, and text
- **`MAUI hittest <x> <y> [--window W]`** — new CLI command
- **`HitTestAsync`** added to AgentClient driver
- Updated README.md and SKILL.md command tables

## Testing

Verified on Mac Catalyst sample app:
- `curl http://localhost:10224/api/hittest?x=200&y=200` → returns Border, CollectionView, Grid, MainPage, AppShell
- Off-screen coordinates return empty elements array
- CLI command works end-to-end

Fixes #23