### PR TITLE
feat: capture Console and Trace/Debug output into file log pipeline

### DIFF
--- a/src/MauiDevFlow.Agent.Core/AgentOptions.cs
+++ b/src/MauiDevFlow.Agent.Core/AgentOptions.cs
@@ -30,6 +30,13 @@ public class AgentOptions
     public bool EnableFileLogging { get; set; } = true;
 
     /// <summary>
+    /// Whether to register the FileLogProvider as an ILoggerProvider so that
+    /// ILogger output is written to the rotating log files. Default: true.
+    /// Requires <see cref="EnableFileLogging"/> to be true.
+    /// </summary>
+    public bool CaptureILogger { get; set; } = true;
+
+    /// <summary>
     /// Maximum size of each log file in bytes before rotation. Default: 1MB.
     /// </summary>
     public long MaxLogFileSize { get; set; } = 1_048_576;
@@ -40,11 +47,17 @@ public class AgentOptions
     public int MaxLogFiles { get; set; } = 5;
 
     /// <summary>
-    /// Whether to capture Console.Out, Console.Error, and Trace/Debug output
-    /// into the file log pipeline. Output is tee'd — original streams still receive everything.
-    /// Default: true.
+    /// Whether to capture Console.Out and Console.Error output into the file log pipeline.
+    /// Output is tee'd — original streams still receive everything. Default: true.
+    /// Requires <see cref="EnableFileLogging"/> to be true.
     /// </summary>
-    public bool CaptureConsoleOutput { get; set; } = true;
+    public bool CaptureConsole { get; set; } = true;
+
+    /// <summary>
+    /// Whether to capture Trace/Debug output into the file log pipeline. Default: true.
+    /// Requires <see cref="EnableFileLogging"/> to be true.
+    /// </summary>
+    public bool CaptureTrace { get; set; } = true;
 
     /// <summary>
     /// Whether to intercept HttpClient requests for network monitoring. Default: true.

--- a/src/MauiDevFlow.Agent.Gtk/GtkAgentServiceExtensions.cs
+++ b/src/MauiDevFlow.Agent.Gtk/GtkAgentServiceExtensions.cs
@@ -72,12 +72,14 @@ public static class GtkAgentServiceExtensions
                 "mauidevflow-logs");
             var logProvider = new FileLogProvider(logDir, options.MaxLogFileSize, options.MaxLogFiles);
             service.SetLogProvider(logProvider);
-            builder.Logging.AddProvider(logProvider);
 
-            if (options.CaptureConsoleOutput)
+            if (options.CaptureILogger)
+                builder.Logging.AddProvider(logProvider);
+
+            if (options.CaptureConsole || options.CaptureTrace)
             {
                 var capture = new ConsoleLogCapture(logProvider.Writer);
-                capture.Install();
+                capture.Install(captureConsole: options.CaptureConsole, captureTrace: options.CaptureTrace);
             }
         }
 

--- a/src/MauiDevFlow.Agent/AgentServiceExtensions.cs
+++ b/src/MauiDevFlow.Agent/AgentServiceExtensions.cs
@@ -95,12 +95,14 @@ public static class AgentServiceExtensions
             var logDir = Path.Combine(FileSystem.CacheDirectory, "mauidevflow-logs");
             var logProvider = new FileLogProvider(logDir, options.MaxLogFileSize, options.MaxLogFiles);
             service.SetLogProvider(logProvider);
-            builder.Logging.AddProvider(logProvider);
 
-            if (options.CaptureConsoleOutput)
+            if (options.CaptureILogger)
+                builder.Logging.AddProvider(logProvider);
+
+            if (options.CaptureConsole || options.CaptureTrace)
             {
                 var capture = new ConsoleLogCapture(logProvider.Writer);
-                capture.Install();
+                capture.Install(captureConsole: options.CaptureConsole, captureTrace: options.CaptureTrace);
             }
         }
 

--- a/src/MauiDevFlow.Logging/ConsoleLogCapture.cs
+++ b/src/MauiDevFlow.Logging/ConsoleLogCapture.cs
@@ -31,17 +31,24 @@ public sealed class ConsoleLogCapture : IDisposable
     }
 
     /// <summary>
-    /// Redirects Console.Out, Console.Error, and adds a TraceListener.
+    /// Redirects Console.Out, Console.Error, and/or adds a TraceListener based on flags.
     /// Safe to call multiple times — only installs once.
     /// </summary>
-    public void Install()
+    public void Install(bool captureConsole = true, bool captureTrace = true)
     {
         if (_installed || _disposed) return;
         _installed = true;
 
-        Console.SetOut(_outWriter);
-        Console.SetError(_errorWriter);
-        Trace.Listeners.Add(_traceListener);
+        if (captureConsole)
+        {
+            Console.SetOut(_outWriter);
+            Console.SetError(_errorWriter);
+        }
+
+        if (captureTrace)
+        {
+            Trace.Listeners.Add(_traceListener);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Add ConsoleLogCapture that tees Console.Out, Console.Error, and Trace/Debug output through to the FileLogWriter while preserving original stream output. Entries are tagged with source 'console.out', 'console.error', or 'trace' for filtering.

Enabled by default via AgentOptions.CaptureConsoleOutput. Wired into both MAUI and GTK agent registration paths.