### PR TITLE
Add MCP server transport for Copilot Chat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,32 +448,65 @@ Add to your VS Code MCP settings (`.vscode/mcp.json`):
 
 | Tool | Description |
 |------|-------------|
+| **Inspection** | |
 | `maui_screenshot` | Capture screenshot — **returns image directly** to the AI agent |
 | `maui_tree` | Visual tree as structured JSON with element IDs, types, bounds, properties |
-| `maui_logs` | Structured log entries with level filtering |
-| `maui_network` | Captured HTTP requests with status, timing, sizes |
-| `maui_network_detail` | Full request/response detail including headers and body |
+| `maui_element` | Get detailed info for a single element |
+| `maui_query` | Query elements by type, AutomationId, or text |
+| `maui_query_css` | Query Blazor WebView elements via CSS selector |
+| `maui_hittest` | Find element at screen coordinates |
+| `maui_assert` | Assert an element property matches an expected value |
+| **Interaction** | |
 | `maui_tap` | Tap a UI element by ID |
 | `maui_fill` | Fill text into an Entry/Editor/SearchBar |
 | `maui_clear` | Clear text from an input element |
-| `maui_scroll` | Scroll a ScrollView element |
-| `maui_navigate` | Navigate to a Shell route |
+| `maui_scroll` | Scroll a ScrollView (by delta, item index, or position) |
 | `maui_focus` | Set focus to an element |
+| `maui_navigate` | Navigate to a Shell route |
 | `maui_resize` | Resize the app window |
-| `maui_set_property` | Set a property value at runtime |
+| **Properties** | |
 | `maui_get_property` | Get a property value |
-| `maui_query` | Query elements by type, AutomationId, or text |
-| `maui_query_css` | Query Blazor WebView elements via CSS selector |
-| `maui_element` | Get detailed info for a single element |
-| `maui_hittest` | Find element at screen coordinates |
-| `maui_list_agents` | List connected MAUI apps |
-| `maui_status` | Agent status (platform, version, app name) |
-| `maui_wait` | Wait for an agent to connect |
-| `maui_select_agent` | Set default agent for the session |
+| `maui_set_property` | Set a property value at runtime |
+| **Logging & Network** | |
+| `maui_logs` | Structured log entries with level filtering |
+| `maui_network` | Captured HTTP requests with status, timing, sizes |
+| `maui_network_detail` | Full request/response detail including headers and body |
+| `maui_network_clear` | Clear captured network requests |
+| **Preferences & Storage** | |
+| `maui_preferences_list` | List all known preference keys |
+| `maui_preferences_get` | Get a preference value by key |
+| `maui_preferences_set` | Set a preference value |
+| `maui_preferences_delete` | Remove a preference by key |
+| `maui_preferences_clear` | Clear all preferences |
+| `maui_secure_storage_get` | Get a value from encrypted secure storage |
+| `maui_secure_storage_set` | Set a value in encrypted secure storage |
+| `maui_secure_storage_delete` | Remove a secure storage entry |
+| `maui_secure_storage_clear` | Clear all secure storage entries |
+| **Platform & Device** | |
+| `maui_app_info` | App name, version, package name, build number, theme |
+| `maui_device_info` | Device manufacturer, model, OS version, platform, idiom |
+| `maui_display_info` | Screen width, height, density, orientation, refresh rate |
+| `maui_battery_info` | Battery level, charging state, power source |
+| `maui_connectivity` | Network access status and connection profiles |
+| `maui_geolocation` | Current GPS coordinates |
+| **Sensors** | |
+| `maui_sensors_list` | List available device sensors and their status |
+| `maui_sensors_start` | Start a sensor (Accelerometer, Gyroscope, etc.) |
+| `maui_sensors_stop` | Stop a running sensor |
+| **Recording** | |
+| `maui_recording_start` | Start screen recording |
+| `maui_recording_stop` | Stop recording and save the file |
+| `maui_recording_status` | Check recording status |
+| **Blazor WebView (CDP)** | |
 | `maui_cdp_evaluate` | Execute JavaScript in a Blazor WebView |
 | `maui_cdp_screenshot` | Capture WebView screenshot via CDP |
 | `maui_cdp_source` | Get WebView HTML source |
 | `maui_cdp_webviews` | List registered Blazor WebViews |
+| **Agent Management** | |
+| `maui_list_agents` | List connected MAUI apps |
+| `maui_status` | Agent status (platform, version, app name) |
+| `maui_wait` | Wait for an agent to connect |
+| `maui_select_agent` | Set default agent for the session |
 
 All tools accept an optional `agentPort` parameter. When omitted, the server auto-discovers the connected agent via the broker — same as the CLI.
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,59 @@ directory (or current directory if `--output` is not specified). Existing files 
 The file list is discovered dynamically from the repository, so new reference docs are picked up
 automatically.
 
+## MCP Server
+
+MauiDevFlow includes an MCP (Model Context Protocol) server for integration with AI coding agents in VS Code Copilot Chat, Claude Desktop, and other MCP-compatible hosts. The MCP server returns structured JSON and inline images — enabling AI agents to see screenshots directly and query the visual tree without text parsing.
+
+### Configuration
+
+Add to your VS Code MCP settings (`.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "maui-devflow": {
+      "command": "maui-devflow",
+      "args": ["mcp-serve"],
+      "transportType": "stdio"
+    }
+  }
+}
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `maui_screenshot` | Capture screenshot — **returns image directly** to the AI agent |
+| `maui_tree` | Visual tree as structured JSON with element IDs, types, bounds, properties |
+| `maui_logs` | Structured log entries with level filtering |
+| `maui_network` | Captured HTTP requests with status, timing, sizes |
+| `maui_network_detail` | Full request/response detail including headers and body |
+| `maui_tap` | Tap a UI element by ID |
+| `maui_fill` | Fill text into an Entry/Editor/SearchBar |
+| `maui_clear` | Clear text from an input element |
+| `maui_scroll` | Scroll a ScrollView element |
+| `maui_navigate` | Navigate to a Shell route |
+| `maui_focus` | Set focus to an element |
+| `maui_resize` | Resize the app window |
+| `maui_set_property` | Set a property value at runtime |
+| `maui_get_property` | Get a property value |
+| `maui_query` | Query elements by type, AutomationId, or text |
+| `maui_query_css` | Query Blazor WebView elements via CSS selector |
+| `maui_element` | Get detailed info for a single element |
+| `maui_hittest` | Find element at screen coordinates |
+| `maui_list_agents` | List connected MAUI apps |
+| `maui_status` | Agent status (platform, version, app name) |
+| `maui_wait` | Wait for an agent to connect |
+| `maui_select_agent` | Set default agent for the session |
+| `maui_cdp_evaluate` | Execute JavaScript in a Blazor WebView |
+| `maui_cdp_screenshot` | Capture WebView screenshot via CDP |
+| `maui_cdp_source` | Get WebView HTML source |
+| `maui_cdp_webviews` | List registered Blazor WebViews |
+
+All tools accept an optional `agentPort` parameter. When omitted, the server auto-discovers the connected agent via the broker — same as the CLI.
+
 ## License
 
 MIT

--- a/src/MauiDevFlow.CLI/Broker/BrokerClient.cs
+++ b/src/MauiDevFlow.CLI/Broker/BrokerClient.cs
@@ -139,6 +139,56 @@ public static class BrokerClient
     /// </summary>
     public static int? ReadBrokerPortPublic() => ReadBrokerPort();
 
+    /// <summary>
+    /// High-level port resolution: ensure broker running → resolve by project → auto-select → config fallback → default.
+    /// Returns the resolved agent port.
+    /// </summary>
+    public static async Task<int?> ResolveAgentPortForProjectAsync()
+    {
+        var brokerPort = ReadBrokerPort() ?? BrokerServer.DefaultPort;
+
+        if (!await IsBrokerAliveAsync(brokerPort))
+        {
+            var started = await EnsureBrokerRunningAsync();
+            if (started.HasValue)
+                brokerPort = started.Value;
+            else
+                return ReadConfigPort() ?? 9223;
+        }
+
+        // Try project-specific resolution
+        var csproj = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.csproj").FirstOrDefault();
+        if (csproj is not null)
+        {
+            var port = await ResolveAgentPortAsync(brokerPort, Path.GetFullPath(csproj));
+            if (port.HasValue) return port.Value;
+        }
+
+        // Try auto-select (single agent)
+        var autoPort = await ResolveAgentPortAsync(brokerPort);
+        if (autoPort.HasValue) return autoPort.Value;
+
+        // No single match — return null so callers can handle multi-agent case
+        return null;
+    }
+
+    /// <summary>
+    /// Read port from .mauidevflow config file in the current directory.
+    /// </summary>
+    public static int? ReadConfigPort()
+    {
+        var configPath = Path.Combine(Directory.GetCurrentDirectory(), ".mauidevflow");
+        if (!File.Exists(configPath)) return null;
+        try
+        {
+            var json = JsonSerializer.Deserialize<JsonElement>(File.ReadAllText(configPath));
+            if (json.TryGetProperty("port", out var portEl) && portEl.TryGetInt32(out var p))
+                return p;
+        }
+        catch { }
+        return null;
+    }
+
     private static void CleanupStaleBroker()
     {
         try

--- a/src/MauiDevFlow.CLI/MauiDevFlow.CLI.csproj
+++ b/src/MauiDevFlow.CLI/MauiDevFlow.CLI.csproj
@@ -13,6 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="ModelContextProtocol" Version="1.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Websocket.Client" Version="5.1.2" />

--- a/src/MauiDevFlow.CLI/Mcp/McpAgentSession.cs
+++ b/src/MauiDevFlow.CLI/Mcp/McpAgentSession.cs
@@ -1,0 +1,112 @@
+using System.Net.Sockets;
+using MauiDevFlow.CLI.Broker;
+using MauiDevFlow.Driver;
+
+namespace MauiDevFlow.CLI.Mcp;
+
+public class McpAgentSession
+{
+	public int? DefaultAgentPort { get; set; }
+	public string DefaultAgentHost { get; set; } = "localhost";
+
+	public async Task<AgentClient> GetAgentClientAsync(int? agentPort = null)
+	{
+		var port = agentPort ?? DefaultAgentPort ?? await ResolveAgentPortAsync();
+		return new AgentClient(DefaultAgentHost, port);
+	}
+
+	public async Task<int> GetBrokerPortAsync()
+	{
+		var port = BrokerClient.ReadBrokerPortPublic() ?? BrokerServer.DefaultPort;
+		if (!IsTcpAlive(port, timeout: 300))
+		{
+			var started = await BrokerClient.EnsureBrokerRunningAsync();
+			if (started.HasValue)
+				port = started.Value;
+		}
+		return port;
+	}
+
+	public async Task<AgentRegistration[]?> ListAgentsAsync()
+	{
+		var brokerPort = await GetBrokerPortAsync();
+		return await BrokerClient.ListAgentsAsync(brokerPort);
+	}
+
+	private async Task<int> ResolveAgentPortAsync()
+	{
+		var brokerPort = BrokerClient.ReadBrokerPortPublic() ?? BrokerServer.DefaultPort;
+		var brokerAlive = IsTcpAlive(brokerPort, timeout: 300);
+
+		if (!brokerAlive)
+		{
+			var started = await BrokerClient.EnsureBrokerRunningAsync();
+			if (started.HasValue)
+			{
+				brokerPort = started.Value;
+				brokerAlive = true;
+			}
+		}
+
+		if (brokerAlive)
+		{
+			// Try project-specific resolution
+			var csprojPath = FindCsprojInCurrentDirectory();
+			if (csprojPath is not null)
+			{
+				var resolved = await BrokerClient.ResolveAgentPortAsync(brokerPort, csprojPath);
+				if (resolved.HasValue)
+					return resolved.Value;
+			}
+
+			// Try auto-select (single agent)
+			var auto = await BrokerClient.ResolveAgentPortAsync(brokerPort);
+			if (auto.HasValue)
+				return auto.Value;
+		}
+
+		// Fall back to config file or default
+		return ReadConfigPort() ?? 9223;
+	}
+
+	private static bool IsTcpAlive(int port, int timeout)
+	{
+		try
+		{
+			using var tcp = new TcpClient();
+			var result = tcp.BeginConnect("localhost", port, null, null);
+			var connected = result.AsyncWaitHandle.WaitOne(timeout);
+			if (connected && tcp.Connected)
+			{
+				tcp.EndConnect(result);
+				return true;
+			}
+			return false;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	private static string? FindCsprojInCurrentDirectory()
+	{
+		var dir = Directory.GetCurrentDirectory();
+		var files = Directory.GetFiles(dir, "*.csproj");
+		return files.Length > 0 ? files[0] : null;
+	}
+
+	private static int? ReadConfigPort()
+	{
+		var configPath = Path.Combine(Directory.GetCurrentDirectory(), ".mauidevflow");
+		if (!File.Exists(configPath)) return null;
+		try
+		{
+			var json = System.Text.Json.JsonDocument.Parse(File.ReadAllText(configPath));
+			if (json.RootElement.TryGetProperty("port", out var portEl) && portEl.TryGetInt32(out var p))
+				return p;
+		}
+		catch { }
+		return null;
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/McpAgentSession.cs
+++ b/src/MauiDevFlow.CLI/Mcp/McpAgentSession.cs
@@ -1,4 +1,3 @@
-using System.Net.Sockets;
 using MauiDevFlow.CLI.Broker;
 using MauiDevFlow.Driver;
 
@@ -17,14 +16,8 @@ public class McpAgentSession
 
 	public async Task<int> GetBrokerPortAsync()
 	{
-		var port = BrokerClient.ReadBrokerPortPublic() ?? BrokerServer.DefaultPort;
-		if (!IsTcpAlive(port, timeout: 300))
-		{
-			var started = await BrokerClient.EnsureBrokerRunningAsync();
-			if (started.HasValue)
-				port = started.Value;
-		}
-		return port;
+		var port = await BrokerClient.EnsureBrokerRunningAsync();
+		return port ?? BrokerServer.DefaultPort;
 	}
 
 	public async Task<AgentRegistration[]?> ListAgentsAsync()
@@ -35,78 +28,8 @@ public class McpAgentSession
 
 	private async Task<int> ResolveAgentPortAsync()
 	{
-		var brokerPort = BrokerClient.ReadBrokerPortPublic() ?? BrokerServer.DefaultPort;
-		var brokerAlive = IsTcpAlive(brokerPort, timeout: 300);
-
-		if (!brokerAlive)
-		{
-			var started = await BrokerClient.EnsureBrokerRunningAsync();
-			if (started.HasValue)
-			{
-				brokerPort = started.Value;
-				brokerAlive = true;
-			}
-		}
-
-		if (brokerAlive)
-		{
-			// Try project-specific resolution
-			var csprojPath = FindCsprojInCurrentDirectory();
-			if (csprojPath is not null)
-			{
-				var resolved = await BrokerClient.ResolveAgentPortAsync(brokerPort, csprojPath);
-				if (resolved.HasValue)
-					return resolved.Value;
-			}
-
-			// Try auto-select (single agent)
-			var auto = await BrokerClient.ResolveAgentPortAsync(brokerPort);
-			if (auto.HasValue)
-				return auto.Value;
-		}
-
-		// Fall back to config file or default
-		return ReadConfigPort() ?? 9223;
-	}
-
-	private static bool IsTcpAlive(int port, int timeout)
-	{
-		try
-		{
-			using var tcp = new TcpClient();
-			var result = tcp.BeginConnect("localhost", port, null, null);
-			var connected = result.AsyncWaitHandle.WaitOne(timeout);
-			if (connected && tcp.Connected)
-			{
-				tcp.EndConnect(result);
-				return true;
-			}
-			return false;
-		}
-		catch
-		{
-			return false;
-		}
-	}
-
-	private static string? FindCsprojInCurrentDirectory()
-	{
-		var dir = Directory.GetCurrentDirectory();
-		var files = Directory.GetFiles(dir, "*.csproj");
-		return files.Length > 0 ? files[0] : null;
-	}
-
-	private static int? ReadConfigPort()
-	{
-		var configPath = Path.Combine(Directory.GetCurrentDirectory(), ".mauidevflow");
-		if (!File.Exists(configPath)) return null;
-		try
-		{
-			var json = System.Text.Json.JsonDocument.Parse(File.ReadAllText(configPath));
-			if (json.RootElement.TryGetProperty("port", out var portEl) && portEl.TryGetInt32(out var p))
-				return p;
-		}
-		catch { }
-		return null;
+		return await BrokerClient.ResolveAgentPortForProjectAsync()
+			?? BrokerClient.ReadConfigPort()
+			?? 9223;
 	}
 }

--- a/src/MauiDevFlow.CLI/Mcp/McpServerHost.cs
+++ b/src/MauiDevFlow.CLI/Mcp/McpServerHost.cs
@@ -33,7 +33,10 @@ public static class McpServerHost
 			.WithTools<AgentTools>()
 			.WithTools<CdpTools>()
 			.WithTools<AssertTool>()
-			.WithTools<RecordingTools>();
+			.WithTools<RecordingTools>()
+			.WithTools<PreferencesTools>()
+			.WithTools<PlatformTools>()
+			.WithTools<SensorTools>();
 
 		await builder.Build().RunAsync();
 	}

--- a/src/MauiDevFlow.CLI/Mcp/McpServerHost.cs
+++ b/src/MauiDevFlow.CLI/Mcp/McpServerHost.cs
@@ -31,7 +31,9 @@ public static class McpServerHost
 			.WithTools<NavigationTools>()
 			.WithTools<QueryTools>()
 			.WithTools<AgentTools>()
-			.WithTools<CdpTools>();
+			.WithTools<CdpTools>()
+			.WithTools<AssertTool>()
+			.WithTools<RecordingTools>();
 
 		await builder.Build().RunAsync();
 	}

--- a/src/MauiDevFlow.CLI/Mcp/McpServerHost.cs
+++ b/src/MauiDevFlow.CLI/Mcp/McpServerHost.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol;
+using MauiDevFlow.CLI.Mcp.Tools;
+
+namespace MauiDevFlow.CLI.Mcp;
+
+public static class McpServerHost
+{
+	public static async Task RunAsync()
+	{
+		var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+
+		var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings { Args = [] });
+
+		builder.Services.AddSingleton<McpAgentSession>();
+
+		builder.Services
+			.AddMcpServer(options =>
+			{
+				options.ServerInfo = new() { Name = "maui-devflow", Version = version };
+			})
+			.WithStdioServerTransport()
+			.WithTools<ScreenshotTool>()
+			.WithTools<TreeTool>()
+			.WithTools<LogsTool>()
+			.WithTools<NetworkTool>()
+			.WithTools<InteractionTools>()
+			.WithTools<PropertyTools>()
+			.WithTools<NavigationTools>()
+			.WithTools<QueryTools>()
+			.WithTools<AgentTools>()
+			.WithTools<CdpTools>();
+
+		await builder.Build().RunAsync();
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/AgentTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/AgentTools.cs
@@ -1,0 +1,102 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+using MauiDevFlow.CLI.Broker;
+using MauiDevFlow.Driver;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class AgentTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    [McpServerTool(Name = "maui_list_agents"), Description("List all connected MAUI DevFlow agents (running apps). Shows app name, platform, port, and uptime.")]
+    public static async Task<string> ListAgents(McpAgentSession session)
+    {
+        var agents = await session.ListAgentsAsync();
+        if (agents == null || agents.Length == 0)
+            return "No agents connected. Build and run a MAUI app with MauiDevFlow.Agent configured.";
+
+        var result = agents.Select(a => new
+        {
+            a.Id,
+            a.AppName,
+            a.Platform,
+            a.Tfm,
+            a.Port,
+            a.Version,
+            uptime = (DateTime.UtcNow - a.ConnectedAt).ToString(@"hh\:mm\:ss")
+        });
+
+        return JsonSerializer.Serialize(result, JsonOptions);
+    }
+
+    [McpServerTool(Name = "maui_status"), Description("Get detailed status of a connected MAUI DevFlow agent including platform, device type, app name, and version.")]
+    public static async Task<string> Status(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+        [Description("Window index for multi-window apps")] int? window = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var status = await agent.GetStatusAsync(window);
+        if (status == null)
+            return "Agent not responding. Is the app running?";
+
+        return JsonSerializer.Serialize(status, JsonOptions);
+    }
+
+    [McpServerTool(Name = "maui_wait"), Description("Wait for a MAUI DevFlow agent to connect. Blocks until an agent registers with the broker or timeout is reached.")]
+    public static async Task<string> Wait(
+        McpAgentSession session,
+        [Description("Timeout in seconds (default: 30)")] int timeout = 30,
+        [Description("Wait for a specific app name")] string? app = null)
+    {
+        var brokerPort = await session.GetBrokerPortAsync();
+        var deadline = DateTime.UtcNow.AddSeconds(timeout);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var agents = await BrokerClient.ListAgentsAsync(brokerPort);
+            if (agents != null && agents.Length > 0)
+            {
+                var match = app != null
+                    ? agents.FirstOrDefault(a => a.AppName?.Contains(app, StringComparison.OrdinalIgnoreCase) == true)
+                    : agents.FirstOrDefault();
+
+                if (match != null)
+                {
+                    session.DefaultAgentPort = match.Port;
+                    return JsonSerializer.Serialize(new
+                    {
+                        match.Id,
+                        match.AppName,
+                        match.Platform,
+                        match.Tfm,
+                        match.Port,
+                        match.Version
+                    }, JsonOptions);
+                }
+            }
+
+            await Task.Delay(500);
+        }
+
+        return $"Timeout after {timeout}s — no agent connected" + (app != null ? $" matching '{app}'" : "") + ".";
+    }
+
+    [McpServerTool(Name = "maui_select_agent"), Description("Set the default agent for this MCP session. Subsequent tool calls will use this agent automatically without needing agentPort.")]
+    public static string SelectAgent(
+        McpAgentSession session,
+        [Description("Agent HTTP port to use as default")] int agentPort)
+    {
+        session.DefaultAgentPort = agentPort;
+        return $"Default agent set to port {agentPort}. All subsequent commands will use this agent.";
+    }
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/AssertTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/AssertTool.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class AssertTool
+{
+	[McpServerTool(Name = "maui_assert"), Description("Assert that a UI element's property equals an expected value. Returns PASS/FAIL with actual vs expected. Use maui_tree to discover element IDs and property names.")]
+	public static async Task<string> Assert(
+		McpAgentSession session,
+		[Description("Property name to check (e.g. Text, IsVisible, IsEnabled)")] string propertyName,
+		[Description("Expected property value")] string expectedValue,
+		[Description("Element ID from the visual tree (use either this or automationId)")] string? elementId = null,
+		[Description("AutomationId to resolve the element")] string? automationId = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+
+		var resolvedId = elementId;
+		if (resolvedId is null && automationId is not null)
+		{
+			var results = await agent.QueryAsync(automationId: automationId);
+			if (results.Count == 0)
+				return $"FAIL: No element found with AutomationId '{automationId}'";
+			resolvedId = results[0].Id;
+		}
+
+		if (resolvedId is null)
+			return "FAIL: Either elementId or automationId must be provided";
+
+		var actualValue = await agent.GetPropertyAsync(resolvedId, propertyName);
+		var passed = string.Equals(actualValue, expectedValue, StringComparison.Ordinal);
+
+		return passed
+			? $"PASS: {propertyName} == \"{expectedValue}\""
+			: $"FAIL: {propertyName} expected \"{expectedValue}\" but got \"{actualValue ?? "(null)"}\"";
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/CdpTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/CdpTools.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Protocol;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class CdpTools
+{
+    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };
+
+    [McpServerTool(Name = "maui_cdp_evaluate"), Description("Execute JavaScript in a Blazor WebView via Chrome DevTools Protocol. Returns the evaluation result.")]
+    public static async Task<string> CdpEvaluate(
+        McpAgentSession session,
+        [Description("JavaScript expression to evaluate")] string expression,
+        [Description("WebView ID or index to target (optional if only one WebView)")] string? webviewId = null,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var url = $"{agent.BaseUrl}/api/cdp";
+        if (webviewId != null)
+            url += $"?webview={Uri.EscapeDataString(webviewId)}";
+
+        var body = JsonSerializer.Serialize(new
+        {
+            method = "Runtime.evaluate",
+            @params = new { expression, returnByValue = true }
+        });
+
+        var response = await _http.PostAsync(url, new StringContent(body, Encoding.UTF8, "application/json"));
+        var content = await response.Content.ReadAsStringAsync();
+
+        try
+        {
+            var json = JsonSerializer.Deserialize<JsonElement>(content);
+            if (json.TryGetProperty("result", out var result) &&
+                result.TryGetProperty("result", out var inner) &&
+                inner.TryGetProperty("value", out var value))
+            {
+                return value.ToString();
+            }
+            return content;
+        }
+        catch
+        {
+            return content;
+        }
+    }
+
+    [McpServerTool(Name = "maui_cdp_screenshot"), Description("Capture a screenshot of a Blazor WebView via Chrome DevTools Protocol. Returns the image directly.")]
+    public static async Task<ContentBlock[]> CdpScreenshot(
+        McpAgentSession session,
+        [Description("WebView ID or index to target (optional if only one WebView)")] string? webviewId = null,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var url = $"{agent.BaseUrl}/api/cdp";
+        if (webviewId != null)
+            url += $"?webview={Uri.EscapeDataString(webviewId)}";
+
+        var body = JsonSerializer.Serialize(new
+        {
+            method = "Page.captureScreenshot",
+            @params = new { format = "png" }
+        });
+
+        var response = await _http.PostAsync(url, new StringContent(body, Encoding.UTF8, "application/json"));
+        var content = await response.Content.ReadAsStringAsync();
+
+        var json = JsonSerializer.Deserialize<JsonElement>(content);
+        if (json.TryGetProperty("result", out var result) &&
+            result.TryGetProperty("data", out var data))
+        {
+            var pngBytes = Convert.FromBase64String(data.GetString()!);
+            return [
+                new TextContentBlock { Text = $"WebView screenshot captured ({pngBytes.Length} bytes)" },
+                ImageContentBlock.FromBytes(pngBytes, "image/png")
+            ];
+        }
+
+        throw new McpException("Failed to capture WebView screenshot. Is a Blazor WebView active?");
+    }
+
+    [McpServerTool(Name = "maui_cdp_source"), Description("Get the HTML source of a Blazor WebView.")]
+    public static async Task<string> CdpSource(
+        McpAgentSession session,
+        [Description("WebView ID or index to target (optional if only one WebView)")] string? webviewId = null,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var source = await agent.GetCdpSourceAsync(webviewId);
+        return string.IsNullOrEmpty(source) ? "No WebView source available." : source;
+    }
+
+    [McpServerTool(Name = "maui_cdp_webviews"), Description("List all registered Blazor WebViews in the running app.")]
+    public static async Task<string> CdpWebViews(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var webviews = await agent.GetCdpWebViewsAsync();
+        return webviews.ToString();
+    }
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/CdpTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/CdpTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text;
 using System.Text.Json;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
@@ -11,8 +10,6 @@ namespace MauiDevFlow.CLI.Mcp.Tools;
 [McpServerToolType]
 public sealed class CdpTools
 {
-    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };
-
     [McpServerTool(Name = "maui_cdp_evaluate"), Description("Execute JavaScript in a Blazor WebView via Chrome DevTools Protocol. Returns the evaluation result.")]
     public static async Task<string> CdpEvaluate(
         McpAgentSession session,
@@ -21,33 +18,23 @@ public sealed class CdpTools
         [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
     {
         var agent = await session.GetAgentClientAsync(agentPort);
-        var url = $"{agent.BaseUrl}/api/cdp";
-        if (webviewId != null)
-            url += $"?webview={Uri.EscapeDataString(webviewId)}";
-
-        var body = JsonSerializer.Serialize(new
-        {
-            method = "Runtime.evaluate",
-            @params = new { expression, returnByValue = true }
-        });
-
-        var response = await _http.PostAsync(url, new StringContent(body, Encoding.UTF8, "application/json"));
-        var content = await response.Content.ReadAsStringAsync();
+        var paramsEl = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(new { expression, returnByValue = true }));
+        var content = await agent.SendCdpCommandAsync("Runtime.evaluate", paramsEl, webviewId);
 
         try
         {
-            var json = JsonSerializer.Deserialize<JsonElement>(content);
-            if (json.TryGetProperty("result", out var result) &&
+            if (content.TryGetProperty("result", out var result) &&
                 result.TryGetProperty("result", out var inner) &&
                 inner.TryGetProperty("value", out var value))
             {
                 return value.ToString();
             }
-            return content;
+            return content.ToString();
         }
         catch
         {
-            return content;
+            return content.ToString();
         }
     }
 
@@ -58,20 +45,10 @@ public sealed class CdpTools
         [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
     {
         var agent = await session.GetAgentClientAsync(agentPort);
-        var url = $"{agent.BaseUrl}/api/cdp";
-        if (webviewId != null)
-            url += $"?webview={Uri.EscapeDataString(webviewId)}";
+        var paramsEl = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(new { format = "png" }));
+        var json = await agent.SendCdpCommandAsync("Page.captureScreenshot", paramsEl, webviewId);
 
-        var body = JsonSerializer.Serialize(new
-        {
-            method = "Page.captureScreenshot",
-            @params = new { format = "png" }
-        });
-
-        var response = await _http.PostAsync(url, new StringContent(body, Encoding.UTF8, "application/json"));
-        var content = await response.Content.ReadAsStringAsync();
-
-        var json = JsonSerializer.Deserialize<JsonElement>(content);
         if (json.TryGetProperty("result", out var result) &&
             result.TryGetProperty("data", out var data))
         {

--- a/src/MauiDevFlow.CLI/Mcp/Tools/InteractionTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/InteractionTools.cs
@@ -47,20 +47,23 @@ public sealed class InteractionTools
 			: $"Failed to clear element '{elementId}'.";
 	}
 
-	[McpServerTool(Name = "maui_scroll"), Description("Scroll a ScrollView element by delta X and Y values.")]
+	[McpServerTool(Name = "maui_scroll"), Description("Scroll a ScrollView, CollectionView, or ListView. Supports delta-based scrolling, scrolling to an item index, or scrolling an element into view.")]
 	public static async Task<string> Scroll(
 		McpAgentSession session,
-		[Description("Element ID of the ScrollView")] string elementId,
+		[Description("Element ID of the scroll container, or element to scroll into view")] string? elementId = null,
 		[Description("Horizontal scroll delta in pixels")] double? x = null,
 		[Description("Vertical scroll delta in pixels")] double? y = null,
 		[Description("Whether to animate the scroll (default: true)")] bool? animated = null,
 		[Description("Window index for multi-window apps")] int? window = null,
+		[Description("Item index to scroll to (for CollectionView/ListView)")] int? itemIndex = null,
+		[Description("Group index for grouped CollectionView")] int? groupIndex = null,
+		[Description("Scroll position: MakeVisible (default), Start, Center, End")] string? scrollToPosition = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var success = await agent.ScrollAsync(elementId, x ?? 0, y ?? 0, animated ?? true, window);
+		var success = await agent.ScrollAsync(elementId, x ?? 0, y ?? 0, animated ?? true, window, itemIndex, groupIndex, scrollToPosition);
 		return success
-			? $"Scrolled element '{elementId}' successfully."
+			? elementId is not null ? $"Scrolled element '{elementId}' successfully." : "Scrolled successfully."
 			: $"Failed to scroll element '{elementId}'. Element may not be a ScrollView.";
 	}
 }

--- a/src/MauiDevFlow.CLI/Mcp/Tools/InteractionTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/InteractionTools.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class InteractionTools
+{
+	[McpServerTool(Name = "maui_tap"), Description("Tap a UI element by its visual tree ID. Use maui_tree to discover element IDs.")]
+	public static async Task<string> Tap(
+		McpAgentSession session,
+		[Description("Element ID from the visual tree")] string elementId,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.TapAsync(elementId);
+		return success
+			? $"Tapped element '{elementId}' successfully."
+			: $"Failed to tap element '{elementId}'. Element may not exist or is not tappable.";
+	}
+
+	[McpServerTool(Name = "maui_fill"), Description("Fill text into an Entry, Editor, or SearchBar element. Replaces existing text.")]
+	public static async Task<string> Fill(
+		McpAgentSession session,
+		[Description("Element ID from the visual tree")] string elementId,
+		[Description("Text to fill into the element")] string text,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.FillAsync(elementId, text);
+		return success
+			? $"Filled element '{elementId}' with text."
+			: $"Failed to fill element '{elementId}'. Element may not exist or is not a text input.";
+	}
+
+	[McpServerTool(Name = "maui_clear"), Description("Clear text from an Entry, Editor, or SearchBar element.")]
+	public static async Task<string> Clear(
+		McpAgentSession session,
+		[Description("Element ID from the visual tree")] string elementId,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.ClearAsync(elementId);
+		return success
+			? $"Cleared element '{elementId}' successfully."
+			: $"Failed to clear element '{elementId}'.";
+	}
+
+	[McpServerTool(Name = "maui_scroll"), Description("Scroll a ScrollView element by delta X and Y values.")]
+	public static async Task<string> Scroll(
+		McpAgentSession session,
+		[Description("Element ID of the ScrollView")] string elementId,
+		[Description("Horizontal scroll delta in pixels")] double? x = null,
+		[Description("Vertical scroll delta in pixels")] double? y = null,
+		[Description("Whether to animate the scroll (default: true)")] bool? animated = null,
+		[Description("Window index for multi-window apps")] int? window = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.ScrollAsync(elementId, x ?? 0, y ?? 0, animated ?? true, window);
+		return success
+			? $"Scrolled element '{elementId}' successfully."
+			: $"Failed to scroll element '{elementId}'. Element may not be a ScrollView.";
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/LogsTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/LogsTool.cs
@@ -15,11 +15,12 @@ public sealed class LogsTool
 		McpAgentSession session,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
 		[Description("Maximum number of log entries to return (default: 50)")] int limit = 50,
+		[Description("Number of newest entries to skip (for pagination)")] int skip = 0,
 		[Description("Minimum log level: trace, debug, info, warning, error, critical")] string? minLevel = null,
 		[Description("Log source filter: native, webview, or all (default: all)")] string? source = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var url = $"{agent.BaseUrl}/api/logs?limit={limit}";
+		var url = $"{agent.BaseUrl}/api/logs?limit={limit}&skip={skip}";
 		if (!string.IsNullOrEmpty(source) && source != "all")
 			url += $"&source={source}";
 

--- a/src/MauiDevFlow.CLI/Mcp/Tools/LogsTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/LogsTool.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class LogsTool
+{
+	private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(10) };
+
+	[McpServerTool(Name = "maui_logs"), Description("Retrieve app logs (ILogger output and WebView console logs). Returns structured JSON log entries with timestamp, level, category, and message.")]
+	public static async Task<string> Logs(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+		[Description("Maximum number of log entries to return (default: 50)")] int limit = 50,
+		[Description("Minimum log level: trace, debug, info, warning, error, critical")] string? minLevel = null,
+		[Description("Log source filter: native, webview, or all (default: all)")] string? source = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var url = $"{agent.BaseUrl}/api/logs?limit={limit}";
+		if (!string.IsNullOrEmpty(source) && source != "all")
+			url += $"&source={source}";
+
+		var response = await _http.GetStringAsync(url);
+
+		if (string.IsNullOrEmpty(minLevel))
+			return response;
+
+		var levelOrder = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+		{
+			["trace"] = 0, ["debug"] = 1, ["info"] = 2, ["information"] = 2,
+			["warning"] = 3, ["warn"] = 3, ["error"] = 4, ["critical"] = 5, ["fatal"] = 5
+		};
+
+		if (!levelOrder.TryGetValue(minLevel, out var minOrd))
+			return response;
+
+		var entries = JsonSerializer.Deserialize<JsonElement>(response);
+		if (entries.ValueKind != JsonValueKind.Array)
+			return response;
+
+		var filtered = entries.EnumerateArray()
+			.Where(e =>
+			{
+				var level = e.TryGetProperty("l", out var l) ? l.GetString() :
+				            e.TryGetProperty("level", out var lv) ? lv.GetString() : null;
+				if (level == null) return true;
+				return levelOrder.TryGetValue(level, out var ord) && ord >= minOrd;
+			})
+			.ToList();
+
+		return JsonSerializer.Serialize(filtered);
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/LogsTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/LogsTool.cs
@@ -8,8 +8,6 @@ namespace MauiDevFlow.CLI.Mcp.Tools;
 [McpServerToolType]
 public sealed class LogsTool
 {
-	private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(10) };
-
 	[McpServerTool(Name = "maui_logs"), Description("Retrieve app logs (ILogger output and WebView console logs). Returns structured JSON log entries with timestamp, level, category, and message.")]
 	public static async Task<string> Logs(
 		McpAgentSession session,
@@ -20,11 +18,7 @@ public sealed class LogsTool
 		[Description("Log source filter: native, webview, or all (default: all)")] string? source = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var url = $"{agent.BaseUrl}/api/logs?limit={limit}&skip={skip}";
-		if (!string.IsNullOrEmpty(source) && source != "all")
-			url += $"&source={source}";
-
-		var response = await _http.GetStringAsync(url);
+		var response = await agent.GetLogsAsync(limit, skip, source);
 
 		if (string.IsNullOrEmpty(minLevel))
 			return response;

--- a/src/MauiDevFlow.CLI/Mcp/Tools/NavigationTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/NavigationTools.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class NavigationTools
+{
+	[McpServerTool(Name = "maui_navigate"), Description("Navigate to a Shell route in the MAUI app (e.g., '//home', '//settings', '//blazor').")]
+	public static async Task<string> Navigate(
+		McpAgentSession session,
+		[Description("Shell route to navigate to (e.g., '//home', '//blazor')")] string route,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.NavigateAsync(route);
+		return success
+			? $"Navigated to '{route}'."
+			: $"Failed to navigate to '{route}'. Route may not exist in the Shell.";
+	}
+
+	[McpServerTool(Name = "maui_focus"), Description("Set focus to a UI element.")]
+	public static async Task<string> Focus(
+		McpAgentSession session,
+		[Description("Element ID from the visual tree")] string elementId,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.FocusAsync(elementId);
+		return success
+			? $"Focused element '{elementId}'."
+			: $"Failed to focus element '{elementId}'.";
+	}
+
+	[McpServerTool(Name = "maui_resize"), Description("Resize the app window.")]
+	public static async Task<string> Resize(
+		McpAgentSession session,
+		[Description("New window width in pixels")] int width,
+		[Description("New window height in pixels")] int height,
+		[Description("Window index for multi-window apps")] int? window = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.ResizeAsync(width, height, window);
+		return success
+			? $"Resized window to {width}x{height}."
+			: "Failed to resize window.";
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/NetworkTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/NetworkTool.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+using MauiDevFlow.Driver;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class NetworkTool
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+		WriteIndented = false
+	};
+
+	[McpServerTool(Name = "maui_network"), Description("List captured HTTP network requests from the running app. Returns structured data with method, URL, status code, duration, and sizes.")]
+	public static async Task<string> NetworkList(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+		[Description("Maximum number of requests to return (default: 50)")] int limit = 50,
+		[Description("Filter by host name")] string? host = null,
+		[Description("Filter by HTTP method (GET, POST, etc.)")] string? method = null,
+		[Description("Filter by status: '4xx', '5xx', '200', etc.")] string? statusFilter = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var requests = await agent.GetNetworkRequestsAsync(limit, host, method);
+		if (requests == null || requests.Count == 0)
+			return "No network requests captured. Ensure DevFlowHttpHandler is configured in the app.";
+
+		if (!string.IsNullOrEmpty(statusFilter))
+		{
+			requests = statusFilter.ToLowerInvariant() switch
+			{
+				"4xx" => requests.Where(r => r.StatusCode >= 400 && r.StatusCode < 500).ToList(),
+				"5xx" => requests.Where(r => r.StatusCode >= 500 && r.StatusCode < 600).ToList(),
+				"2xx" => requests.Where(r => r.StatusCode >= 200 && r.StatusCode < 300).ToList(),
+				"3xx" => requests.Where(r => r.StatusCode >= 300 && r.StatusCode < 400).ToList(),
+				_ when int.TryParse(statusFilter, out var code) => requests.Where(r => r.StatusCode == code).ToList(),
+				_ => requests
+			};
+		}
+
+		return JsonSerializer.Serialize(requests, JsonOptions);
+	}
+
+	[McpServerTool(Name = "maui_network_detail"), Description("Get full details of a captured HTTP request including headers and body.")]
+	public static async Task<string> NetworkDetail(
+		McpAgentSession session,
+		[Description("The request ID from maui_network results")] string requestId,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var detail = await agent.GetNetworkRequestDetailAsync(requestId);
+		if (detail == null)
+			return $"Network request '{requestId}' not found.";
+
+		return JsonSerializer.Serialize(detail, JsonOptions);
+	}
+
+	[McpServerTool(Name = "maui_network_clear"), Description("Clear all captured network requests from the buffer.")]
+	public static async Task<string> NetworkClear(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.ClearNetworkRequestsAsync();
+		return success ? "Network request buffer cleared." : "Failed to clear network requests.";
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/PlatformTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/PlatformTools.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class PlatformTools
+{
+	[McpServerTool(Name = "maui_app_info"), Description("Get app name, version, package name, build number, and theme.")]
+	public static async Task<string> GetAppInfo(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetPlatformInfoAsync("app-info");
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get app info." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_device_info"), Description("Get device manufacturer, model, OS version, platform, and idiom.")]
+	public static async Task<string> GetDeviceInfo(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetPlatformInfoAsync("device-info");
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get device info." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_display_info"), Description("Get screen width, height, density, orientation, rotation, and refresh rate.")]
+	public static async Task<string> GetDisplayInfo(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetPlatformInfoAsync("device-display");
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get display info." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_battery_info"), Description("Get battery level, charging state, power source, and energy saver status.")]
+	public static async Task<string> GetBatteryInfo(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetPlatformInfoAsync("battery");
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get battery info." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_connectivity"), Description("Get network access status and connection profiles (WiFi, Cellular, etc.).")]
+	public static async Task<string> GetConnectivity(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetPlatformInfoAsync("connectivity");
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get connectivity info." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_geolocation"), Description("Get current GPS coordinates (latitude, longitude, altitude, accuracy).")]
+	public static async Task<string> GetGeolocation(
+		McpAgentSession session,
+		[Description("Accuracy: default, coarse, fine")] string? accuracy = null,
+		[Description("Timeout in seconds (default: 10)")] int? timeoutSeconds = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetGeolocationAsync(accuracy, timeoutSeconds);
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get geolocation." : result.ToString();
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/PreferencesTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/PreferencesTools.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class PreferencesTools
+{
+	[McpServerTool(Name = "maui_preferences_list"), Description("List all known preference keys from the app's key-value store.")]
+	public static async Task<string> ListPreferences(
+		McpAgentSession session,
+		[Description("Shared preferences name (optional, for shared containers)")] string? sharedName = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetPreferencesAsync(sharedName);
+		return result.ValueKind == JsonValueKind.Undefined ? "No preferences found." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_preferences_get"), Description("Get a preference value by key from the app's key-value store.")]
+	public static async Task<string> GetPreference(
+		McpAgentSession session,
+		[Description("Preference key to retrieve")] string key,
+		[Description("Value type: string, int, bool, double, float, long, datetime (default: string)")] string? type = null,
+		[Description("Shared preferences name (optional)")] string? sharedName = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetPreferenceAsync(key, type, sharedName);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Preference '{key}' not found." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_preferences_set"), Description("Set a preference value in the app's key-value store.")]
+	public static async Task<string> SetPreference(
+		McpAgentSession session,
+		[Description("Preference key")] string key,
+		[Description("Value to store")] string value,
+		[Description("Value type: string, int, bool, double, float, long, datetime (default: string)")] string? type = null,
+		[Description("Shared preferences name (optional)")] string? sharedName = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.SetPreferenceAsync(key, value, type, sharedName);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to set preference '{key}'." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_preferences_delete"), Description("Remove a preference by key from the app's key-value store.")]
+	public static async Task<string> DeletePreference(
+		McpAgentSession session,
+		[Description("Preference key to remove")] string key,
+		[Description("Shared preferences name (optional)")] string? sharedName = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.DeletePreferenceAsync(key, sharedName);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to delete preference '{key}'." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_preferences_clear"), Description("Clear all preferences from the app's key-value store.")]
+	public static async Task<string> ClearPreferences(
+		McpAgentSession session,
+		[Description("Shared preferences name (optional)")] string? sharedName = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.ClearPreferencesAsync(sharedName);
+		return success ? "Preferences cleared." : "Failed to clear preferences.";
+	}
+
+	[McpServerTool(Name = "maui_secure_storage_get"), Description("Get a value from the app's encrypted secure storage.")]
+	public static async Task<string> GetSecureStorage(
+		McpAgentSession session,
+		[Description("Secure storage key to retrieve")] string key,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetSecureStorageAsync(key);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Secure storage key '{key}' not found." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_secure_storage_set"), Description("Set a value in the app's encrypted secure storage.")]
+	public static async Task<string> SetSecureStorage(
+		McpAgentSession session,
+		[Description("Secure storage key")] string key,
+		[Description("Value to store")] string value,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.SetSecureStorageAsync(key, value);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to set secure storage key '{key}'." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_secure_storage_delete"), Description("Remove an entry from the app's encrypted secure storage.")]
+	public static async Task<string> DeleteSecureStorage(
+		McpAgentSession session,
+		[Description("Secure storage key to remove")] string key,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.DeleteSecureStorageAsync(key);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to delete secure storage key '{key}'." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_secure_storage_clear"), Description("Clear all entries from the app's encrypted secure storage.")]
+	public static async Task<string> ClearSecureStorage(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.ClearSecureStorageAsync();
+		return success ? "Secure storage cleared." : "Failed to clear secure storage.";
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/PropertyTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/PropertyTools.cs
@@ -1,6 +1,4 @@
 using System.ComponentModel;
-using System.Text;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 using MauiDevFlow.CLI.Mcp;
 
@@ -9,8 +7,6 @@ namespace MauiDevFlow.CLI.Mcp.Tools;
 [McpServerToolType]
 public sealed class PropertyTools
 {
-	private static readonly HttpClient s_http = new() { Timeout = TimeSpan.FromSeconds(10) };
-
 	[McpServerTool(Name = "maui_get_property"), Description("Get the value of a property on a UI element (e.g., Text, IsVisible, BackgroundColor, SelectedIndex).")]
 	public static async Task<string> GetProperty(
 		McpAgentSession session,
@@ -32,21 +28,9 @@ public sealed class PropertyTools
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var json = JsonSerializer.Serialize(new { elementId, property, value });
-		var content = new StringContent(json, Encoding.UTF8, "application/json");
-		try
-		{
-			var response = await s_http.PostAsync($"{agent.BaseUrl}/api/action/set-property", content);
-			var body = await response.Content.ReadAsStringAsync();
-			var result = JsonSerializer.Deserialize<JsonElement>(body);
-			if (result.TryGetProperty("success", out var s) && s.GetBoolean())
-				return $"Set '{property}' = '{value}' on element '{elementId}'.";
-			var error = result.TryGetProperty("error", out var e) ? e.GetString() : "Unknown error";
-			return $"Failed to set property: {error}";
-		}
-		catch (Exception ex)
-		{
-			return $"Failed to set property: {ex.Message}";
-		}
+		var success = await agent.SetPropertyAsync(elementId, property, value);
+		return success
+			? $"Set '{property}' = '{value}' on element '{elementId}'."
+			: $"Failed to set property '{property}' on element '{elementId}'.";
 	}
 }

--- a/src/MauiDevFlow.CLI/Mcp/Tools/PropertyTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/PropertyTools.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class PropertyTools
+{
+	private static readonly HttpClient s_http = new() { Timeout = TimeSpan.FromSeconds(10) };
+
+	[McpServerTool(Name = "maui_get_property"), Description("Get the value of a property on a UI element (e.g., Text, IsVisible, BackgroundColor, SelectedIndex).")]
+	public static async Task<string> GetProperty(
+		McpAgentSession session,
+		[Description("Element ID from the visual tree")] string elementId,
+		[Description("Property name (e.g., 'Text', 'IsVisible', 'BackgroundColor')")] string property,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var value = await agent.GetPropertyAsync(elementId, property);
+		return value ?? $"Property '{property}' not found on element '{elementId}'.";
+	}
+
+	[McpServerTool(Name = "maui_set_property"), Description("Set a property value on a UI element at runtime (e.g., Text, IsVisible, BackgroundColor, SelectedIndex).")]
+	public static async Task<string> SetProperty(
+		McpAgentSession session,
+		[Description("Element ID from the visual tree")] string elementId,
+		[Description("Property name (e.g., 'Text', 'IsVisible', 'BackgroundColor')")] string property,
+		[Description("New value for the property")] string value,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var json = JsonSerializer.Serialize(new { elementId, property, value });
+		var content = new StringContent(json, Encoding.UTF8, "application/json");
+		try
+		{
+			var response = await s_http.PostAsync($"{agent.BaseUrl}/api/action/set-property", content);
+			var body = await response.Content.ReadAsStringAsync();
+			var result = JsonSerializer.Deserialize<JsonElement>(body);
+			if (result.TryGetProperty("success", out var s) && s.GetBoolean())
+				return $"Set '{property}' = '{value}' on element '{elementId}'.";
+			var error = result.TryGetProperty("error", out var e) ? e.GetString() : "Unknown error";
+			return $"Failed to set property: {error}";
+		}
+		catch (Exception ex)
+		{
+			return $"Failed to set property: {ex.Message}";
+		}
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/QueryTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/QueryTools.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+using MauiDevFlow.Driver;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class QueryTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    [McpServerTool(Name = "maui_query"), Description("Query visual tree elements by type, AutomationId, or text content. Returns matching elements with their IDs and properties.")]
+    public static async Task<string> Query(
+        McpAgentSession session,
+        [Description("Element type filter (e.g., 'Button', 'Label', 'Entry')")] string? type = null,
+        [Description("AutomationId to search for")] string? automationId = null,
+        [Description("Text content to search for")] string? text = null,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        if (type == null && automationId == null && text == null)
+            return "At least one filter must be specified: type, automationId, or text.";
+
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var results = await agent.QueryAsync(type, automationId, text);
+        if (results == null || results.Count == 0)
+            return "No matching elements found.";
+
+        return JsonSerializer.Serialize(results, JsonOptions);
+    }
+
+    [McpServerTool(Name = "maui_query_css"), Description("Query Blazor WebView elements using CSS selectors. Returns matching elements.")]
+    public static async Task<string> QueryCss(
+        McpAgentSession session,
+        [Description("CSS selector (e.g., '.my-class', '#myId', 'button.primary')")] string selector,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var results = await agent.QueryCssAsync(selector);
+        if (results == null || results.Count == 0)
+            return $"No elements matching selector '{selector}'.";
+
+        return JsonSerializer.Serialize(results, JsonOptions);
+    }
+
+    [McpServerTool(Name = "maui_element"), Description("Get detailed info about a single element by its visual tree ID.")]
+    public static async Task<string> Element(
+        McpAgentSession session,
+        [Description("Element ID from the visual tree")] string elementId,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var element = await agent.GetElementAsync(elementId);
+        if (element == null)
+            return $"Element '{elementId}' not found.";
+
+        return JsonSerializer.Serialize(element, JsonOptions);
+    }
+
+    [McpServerTool(Name = "maui_hittest"), Description("Find which element is at specific screen coordinates (hit test).")]
+    public static async Task<string> HitTest(
+        McpAgentSession session,
+        [Description("X coordinate in pixels")] double x,
+        [Description("Y coordinate in pixels")] double y,
+        [Description("Window index for multi-window apps")] int? window = null,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var elementId = await agent.HitTestAsync(x, y, window);
+        if (string.IsNullOrEmpty(elementId))
+            return $"No element found at ({x}, {y}).";
+
+        return $"Element at ({x}, {y}): {elementId}";
+    }
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/RecordingTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/RecordingTools.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class RecordingTools
+{
+	[McpServerTool(Name = "maui_recording_start"), Description("Start screen recording of the running app. Uses platform-specific recording (xcrun for iOS/Mac Catalyst, scrcpy for Android).")]
+	public static async Task<string> RecordingStart(
+		McpAgentSession session,
+		[Description("Output file path (default: recording_<timestamp>.mp4)")] string? output = null,
+		[Description("Max recording duration in seconds (default: 30)")] int timeout = 30,
+		[Description("Agent HTTP port (optional, used to detect platform)")] int? agentPort = null)
+	{
+		try
+		{
+			var agent = await session.GetAgentClientAsync(agentPort);
+			var status = await agent.GetStatusAsync();
+			var platform = status?.Platform ?? "maccatalyst";
+
+			var filename = output ?? $"recording_{DateTime.Now:yyyyMMdd_HHmmss}.mp4";
+			using var driver = MauiDevFlow.Driver.AppDriverFactory.Create(platform);
+			await driver.StartRecordingAsync(filename, timeout);
+
+			return $"Recording started (timeout: {timeout}s). Output: {Path.GetFullPath(filename)}";
+		}
+		catch (Exception ex)
+		{
+			return $"Error starting recording: {ex.Message}";
+		}
+	}
+
+	[McpServerTool(Name = "maui_recording_stop"), Description("Stop the active screen recording and save the video file.")]
+	public static async Task<string> RecordingStop(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional, used to detect platform)")] int? agentPort = null)
+	{
+		try
+		{
+			var agent = await session.GetAgentClientAsync(agentPort);
+			var status = await agent.GetStatusAsync();
+			var platform = status?.Platform ?? "maccatalyst";
+
+			using var driver = MauiDevFlow.Driver.AppDriverFactory.Create(platform);
+			var outputFile = await driver.StopRecordingAsync();
+			var size = File.Exists(outputFile) ? new FileInfo(outputFile).Length : 0;
+
+			return $"Recording saved: {outputFile} ({size} bytes)";
+		}
+		catch (Exception ex)
+		{
+			return $"Error stopping recording: {ex.Message}";
+		}
+	}
+
+	[McpServerTool(Name = "maui_recording_status"), Description("Check if a screen recording is currently in progress.")]
+	public static Task<string> RecordingStatus()
+	{
+		var state = MauiDevFlow.Driver.RecordingStateManager.Load();
+		if (state == null || !MauiDevFlow.Driver.RecordingStateManager.IsRecording())
+			return Task.FromResult("No active recording.");
+
+		var elapsed = DateTimeOffset.UtcNow - state.StartedAt;
+		return Task.FromResult(
+			$"Recording in progress: platform={state.Platform}, output={state.OutputFile}, " +
+			$"elapsed={elapsed.TotalSeconds:F0}s/{state.TimeoutSeconds}s, pid={state.RecordingPid}");
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
@@ -15,10 +15,12 @@ public sealed class ScreenshotTool
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
 		[Description("Window index for multi-window apps (default: 0)")] int? window = null,
 		[Description("Element ID to capture a specific element")] string? elementId = null,
-		[Description("CSS selector to capture (first match, Blazor WebViews only)")] string? selector = null)
+		[Description("CSS selector to capture (first match, Blazor WebViews only)")] string? selector = null,
+		[Description("Resize screenshot to this max width in pixels (overrides auto-scaling)")] int? maxWidth = null,
+		[Description("Scale mode: 'native' keeps full HiDPI resolution, default auto-scales to 1x logical pixels")] string? scale = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var bytes = await agent.ScreenshotAsync(window, elementId, selector);
+		var bytes = await agent.ScreenshotAsync(window, elementId, selector, maxWidth, scale);
 		if (bytes == null || bytes.Length == 0)
 			throw new McpException("Screenshot failed — no image data returned. Is the agent connected and the app visible?");
 

--- a/src/MauiDevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Protocol;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class ScreenshotTool
+{
+	[McpServerTool(Name = "maui_screenshot"), Description("Capture a screenshot of the running MAUI app. Returns the image directly for visual verification of layout, colors, contrast, and rendering.")]
+	public static async Task<ContentBlock[]> Screenshot(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+		[Description("Window index for multi-window apps (default: 0)")] int? window = null,
+		[Description("Element ID to capture a specific element")] string? elementId = null,
+		[Description("CSS selector to capture (first match, Blazor WebViews only)")] string? selector = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var bytes = await agent.ScreenshotAsync(window, elementId, selector);
+		if (bytes == null || bytes.Length == 0)
+			throw new McpException("Screenshot failed — no image data returned. Is the agent connected and the app visible?");
+
+		return [
+			new TextContentBlock { Text = $"Screenshot captured ({bytes.Length} bytes, PNG)" },
+			ImageContentBlock.FromBytes(bytes, "image/png")
+		];
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/SensorTools.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/SensorTools.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class SensorTools
+{
+	[McpServerTool(Name = "maui_sensors_list"), Description("List available device sensors and their current status (active/inactive).")]
+	public static async Task<string> ListSensors(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetSensorsAsync();
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to list sensors." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_sensors_start"), Description("Start a device sensor (e.g., Accelerometer, Gyroscope, Magnetometer, Barometer, Compass, OrientationSensor).")]
+	public static async Task<string> StartSensor(
+		McpAgentSession session,
+		[Description("Sensor name (e.g., Accelerometer, Gyroscope, Magnetometer, Barometer, Compass)")] string sensor,
+		[Description("Reading speed: UI, Default, Game, Fastest (default: Default)")] string? speed = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.StartSensorAsync(sensor, speed);
+		return success ? $"Sensor '{sensor}' started." : $"Failed to start sensor '{sensor}'.";
+	}
+
+	[McpServerTool(Name = "maui_sensors_stop"), Description("Stop a running device sensor.")]
+	public static async Task<string> StopSensor(
+		McpAgentSession session,
+		[Description("Sensor name to stop")] string sensor,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.StopSensorAsync(sensor);
+		return success ? $"Sensor '{sensor}' stopped." : $"Failed to stop sensor '{sensor}'.";
+	}
+}

--- a/src/MauiDevFlow.CLI/Mcp/Tools/TreeTool.cs
+++ b/src/MauiDevFlow.CLI/Mcp/Tools/TreeTool.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using MauiDevFlow.CLI.Mcp;
+using MauiDevFlow.Driver;
+
+namespace MauiDevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class TreeTool
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+		WriteIndented = false
+	};
+
+	[McpServerTool(Name = "maui_tree"), Description("Inspect the visual tree of the running MAUI app. Returns structured JSON element hierarchy with IDs, types, bounds, visibility, and properties. Use element IDs from this tree for tap, fill, scroll, and other interaction commands.")]
+	public static async Task<string> Tree(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+		[Description("Window index for multi-window apps (default: 0)")] int? window = null,
+		[Description("Max tree depth to return (default: 50)")] int depth = 50,
+		[Description("Filter to a specific element type, e.g. 'Label', 'Button', 'Entry'")] string? filter = null,
+		[Description("Return only the subtree rooted at this element ID")] string? elementId = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var tree = await agent.GetTreeAsync(depth, window);
+		if (tree == null || tree.Count == 0)
+			return "No visual tree available. Is the agent connected and the app running?";
+
+		IEnumerable<ElementInfo> result = tree;
+
+		if (elementId != null)
+		{
+			var subtree = FindElement(tree, elementId);
+			if (subtree == null)
+				return $"Element '{elementId}' not found in the visual tree.";
+			result = [subtree];
+		}
+
+		if (filter != null)
+		{
+			result = FilterByType(result.ToList(), filter);
+			if (!result.Any())
+				return $"No elements of type '{filter}' found in the visual tree.";
+		}
+
+		return JsonSerializer.Serialize(result, JsonOptions);
+	}
+
+	private static ElementInfo? FindElement(IEnumerable<ElementInfo> elements, string id)
+	{
+		foreach (var el in elements)
+		{
+			if (el.Id == id) return el;
+			if (el.Children != null)
+			{
+				var found = FindElement(el.Children, id);
+				if (found != null) return found;
+			}
+		}
+		return null;
+	}
+
+	private static List<ElementInfo> FilterByType(List<ElementInfo> elements, string type)
+	{
+		var result = new List<ElementInfo>();
+		foreach (var el in elements)
+		{
+			if (el.Type.Equals(type, StringComparison.OrdinalIgnoreCase))
+				result.Add(el);
+			else if (el.Children != null)
+			{
+				var filtered = FilterByType(el.Children, type);
+				if (filtered.Count > 0)
+					result.AddRange(filtered);
+			}
+		}
+		return result;
+	}
+}

--- a/src/MauiDevFlow.CLI/Program.cs
+++ b/src/MauiDevFlow.CLI/Program.cs
@@ -895,6 +895,11 @@ class Program
         }, jsonOption, noJsonOption);
         rootCommand.Add(commandsCmd);
 
+        // ===== MCP server command =====
+        var mcpServeCmd = new Command("mcp-serve", "Start MCP (Model Context Protocol) server for AI agent integration via stdio");
+        mcpServeCmd.SetHandler(async () => await Mcp.McpServerHost.RunAsync());
+        rootCommand.Add(mcpServeCmd);
+
         _parser = new CommandLineBuilder(rootCommand)
             .UseDefaults()
             .Build();

--- a/src/MauiDevFlow.CLI/Program.cs
+++ b/src/MauiDevFlow.CLI/Program.cs
@@ -909,33 +909,16 @@ class Program
         return _errorOccurred ? 1 : result;
     }
     
-    // ===== CDP Helper: Send command via HTTP POST /api/cdp =====
+    // ===== CDP Helper: Send command via AgentClient =====
 
     private static async Task<JsonElement?> SendCdpCommandAsync(string host, int port, string method, object? parameters = null, string? webview = null)
     {
-        using var http = new HttpClient();
-        http.Timeout = TimeSpan.FromSeconds(30);
-
-        var command = new Dictionary<string, object>
-        {
-            ["id"] = 1,
-            ["method"] = method
-        };
-        if (parameters != null)
-            command["params"] = parameters;
-
-        var json = JsonSerializer.Serialize(command);
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
-        var url = string.IsNullOrEmpty(webview)
-            ? $"http://{host}:{port}/api/cdp"
-            : $"http://{host}:{port}/api/cdp?webview={Uri.EscapeDataString(webview)}";
-        var response = await http.PostAsync(url, content);
-        var body = await response.Content.ReadAsStringAsync();
-
-        if (!response.IsSuccessStatusCode)
-            throw new Exception($"CDP request failed ({response.StatusCode}): {body}");
-
-        return JsonSerializer.Deserialize<JsonElement>(body);
+        using var client = new MauiDevFlow.Driver.AgentClient(host, port);
+        JsonElement? paramsEl = parameters != null
+            ? JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(parameters))
+            : null;
+        var result = await client.SendCdpCommandAsync(method, paramsEl, webview);
+        return result;
     }
 
     private static async Task<string> CdpEvaluateAsync(string host, int port, string expression, string? webview = null)
@@ -1189,10 +1172,9 @@ class Program
     {
         try
         {
-            using var http = new HttpClient();
-            http.Timeout = TimeSpan.FromSeconds(5);
-            var response = await http.GetAsync($"http://{host}:{port}/api/cdp/webviews");
-            var body = await response.Content.ReadAsStringAsync();
+            using var client = new MauiDevFlow.Driver.AgentClient(host, port);
+            var result = await client.GetCdpWebViewsAsync();
+            var body = result.ToString();
 
             if (json)
             {
@@ -1200,8 +1182,7 @@ class Program
                 return;
             }
 
-            var doc = JsonDocument.Parse(body);
-            if (doc.RootElement.TryGetProperty("webviews", out var webviews))
+            if (result.TryGetProperty("webviews", out var webviews))
             {
                 if (webviews.GetArrayLength() == 0)
                 {
@@ -1232,21 +1213,9 @@ class Program
     {
         try
         {
-            using var http = new HttpClient();
-            http.Timeout = TimeSpan.FromSeconds(10);
-            var url = $"http://{host}:{port}/api/cdp/source";
-            if (!string.IsNullOrEmpty(webview))
-                url += $"?webview={Uri.EscapeDataString(webview)}";
-            var response = await http.GetAsync(url);
-            var body = await response.Content.ReadAsStringAsync();
-
-            if (!response.IsSuccessStatusCode)
-            {
-                WriteError($"Failed to get page source: {body}");
-                return;
-            }
-
-            Console.WriteLine(body);
+            using var client = new MauiDevFlow.Driver.AgentClient(host, port);
+            var source = await client.GetCdpSourceAsync(webview);
+            Console.WriteLine(source);
         }
         catch (Exception ex)
         {
@@ -2137,21 +2106,16 @@ class Program
     {
         try
         {
-            using var http = new HttpClient();
-            http.Timeout = TimeSpan.FromSeconds(10);
-            var body = JsonSerializer.Serialize(new { value });
-            var content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
-            var response = await http.PostAsync($"http://{host}:{port}/api/property/{elementId}/{propertyName}", content);
-            var responseBody = await response.Content.ReadAsStringAsync();
-
-            if (response.IsSuccessStatusCode)
+            using var client = new MauiDevFlow.Driver.AgentClient(host, port);
+            var success = await client.SetPropertyAsync(elementId, propertyName, value);
+            if (success)
             {
                 OutputWriter.WriteActionResult(true, "SetProperty", elementId, json,
                     $"Set {propertyName} = {value}");
             }
             else
             {
-                OutputWriter.WriteError($"Failed: {responseBody}", json);
+                OutputWriter.WriteError($"Failed to set {propertyName}", json);
                 _errorOccurred = true;
             }
         }
@@ -2245,20 +2209,8 @@ class Program
     {
         try
         {
-            using var http = new HttpClient();
-            http.BaseAddress = new Uri($"http://{host}:{port}");
-            var url = $"/api/logs?limit={limit}&skip={skip}";
-            if (!string.IsNullOrEmpty(source))
-                url += $"&source={Uri.EscapeDataString(source)}";
-            var response = await http.GetAsync(url);
-            var body = await response.Content.ReadAsStringAsync();
-
-            if (!response.IsSuccessStatusCode)
-            {
-                OutputWriter.WriteError($"Failed to fetch logs: {response.StatusCode} {body}", json);
-                _errorOccurred = true;
-                return;
-            }
+            using var client = new MauiDevFlow.Driver.AgentClient(host, port);
+            var body = await client.GetLogsAsync(limit, skip, source);
 
             if (json)
             {
@@ -3125,95 +3077,39 @@ class Program
     /// <summary>
     /// Reads the port from .mauidevflow in the current directory.
     /// </summary>
-    private static int? ReadConfigPort()
-    {
-        try
-        {
-            var path = Path.Combine(Directory.GetCurrentDirectory(), ".mauidevflow");
-            if (!File.Exists(path)) return null;
-
-            var json = File.ReadAllText(path);
-            var doc = JsonDocument.Parse(json);
-            if (doc.RootElement.TryGetProperty("port", out var portProp) && portProp.ValueKind == JsonValueKind.Number)
-                return portProp.GetInt32();
-        }
-        catch { /* ignore parse failures */ }
-        return null;
-    }
-
     /// <summary>
     /// Resolves the agent port: broker discovery → .mauidevflow config → default 9223.
     /// </summary>
     private static int ResolveAgentPort()
     {
-        // Try broker discovery
         try
         {
+            var port = Broker.BrokerClient.ResolveAgentPortForProjectAsync().GetAwaiter().GetResult();
+            if (port.HasValue) return port.Value;
+
+            // No single match — check config file fallback
+            var configPort = Broker.BrokerClient.ReadConfigPort();
+            if (configPort.HasValue) return configPort.Value;
+
+            // Multiple agents, can't disambiguate — show them so the caller
+            // (human or AI agent) can re-run with --agent-port
             var brokerPort = Broker.BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort;
-
-            // Quick TCP check if broker is alive; auto-start if not
-            bool brokerAlive = false;
-            try
+            var agents = Broker.BrokerClient.ListAgentsAsync(brokerPort).GetAwaiter().GetResult();
+            if (agents != null && agents.Length > 1)
             {
-                using var tcp = new System.Net.Sockets.TcpClient();
-                tcp.ConnectAsync("localhost", brokerPort).Wait(TimeSpan.FromMilliseconds(300));
-                brokerAlive = tcp.Connected;
-            }
-            catch { /* connect failed or timed out — broker not alive */ }
-
-            if (!brokerAlive)
-            {
-                // Auto-start broker in background
-                try
-                {
-                    var brokerResult = Broker.BrokerClient.EnsureBrokerRunningAsync().GetAwaiter().GetResult();
-                    if (brokerResult.HasValue)
-                    {
-                        brokerPort = brokerResult.Value;
-                        brokerAlive = true;
-                    }
-                }
-                catch { }
-            }
-
-            if (brokerAlive)
-            {
-                // Find project in current directory
-                var csproj = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.csproj").FirstOrDefault();
-                if (csproj != null)
-                {
-                    var port = Broker.BrokerClient.ResolveAgentPortAsync(brokerPort, Path.GetFullPath(csproj)).GetAwaiter().GetResult();
-                    if (port.HasValue) return port.Value;
-                }
-
-                // Try auto-select (single agent)
-                var autoPort = Broker.BrokerClient.ResolveAgentPortAsync(brokerPort).GetAwaiter().GetResult();
-                if (autoPort.HasValue) return autoPort.Value;
-
-                // Multiple agents, can't disambiguate — show them so the caller
-                // (human or AI agent) can re-run with --agent-port
-                // Only show if we won't have a config file fallback
-                var configPort = ReadConfigPort();
-                if (configPort.HasValue) return configPort.Value;
-
-                var agents = Broker.BrokerClient.ListAgentsAsync(brokerPort).GetAwaiter().GetResult();
-                if (agents != null && agents.Length > 1)
-                {
-                    Console.Error.WriteLine("Multiple agents connected. Use --agent-port to specify which one:");
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine($"{"ID",-15}{"App",-20}{"Platform",-15}{"TFM",-25}{"Port",-7}");
-                    Console.Error.WriteLine(new string('-', 82));
-                    foreach (var a in agents)
-                        Console.Error.WriteLine($"{a.Id,-15}{a.AppName,-20}{a.Platform,-15}{a.Tfm,-25}{a.Port,-7}");
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("Example: maui-devflow MAUI status --agent-port <port>");
-                }
+                Console.Error.WriteLine("Multiple agents connected. Use --agent-port to specify which one:");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"{"ID",-15}{"App",-20}{"Platform",-15}{"TFM",-25}{"Port",-7}");
+                Console.Error.WriteLine(new string('-', 82));
+                foreach (var a in agents)
+                    Console.Error.WriteLine($"{a.Id,-15}{a.AppName,-20}{a.Platform,-15}{a.Tfm,-25}{a.Port,-7}");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Example: maui-devflow MAUI status --agent-port <port>");
             }
         }
         catch { /* broker unavailable, fall through */ }
 
-        // Fall back to config file (already checked above if broker was alive)
-        return ReadConfigPort() ?? 9223;
+        return Broker.BrokerClient.ReadConfigPort() ?? 9223;
     }
 
     // ===== Broker Commands =====

--- a/src/MauiDevFlow.Driver/AgentClient.cs
+++ b/src/MauiDevFlow.Driver/AgentClient.cs
@@ -355,6 +355,121 @@ public class AgentClient : IDisposable
         }
     }
 
+    // ── Preferences ──
+
+    public async Task<JsonElement> GetPreferencesAsync(string? sharedName = null)
+    {
+        var path = "/api/preferences";
+        if (!string.IsNullOrEmpty(sharedName))
+            path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
+        return await GetJsonAsync(path);
+    }
+
+    public async Task<JsonElement> GetPreferenceAsync(string key, string? type = null, string? sharedName = null)
+    {
+        var path = $"/api/preferences/{Uri.EscapeDataString(key)}";
+        var qs = new List<string>();
+        if (!string.IsNullOrEmpty(type)) qs.Add($"type={Uri.EscapeDataString(type)}");
+        if (!string.IsNullOrEmpty(sharedName)) qs.Add($"sharedName={Uri.EscapeDataString(sharedName)}");
+        if (qs.Count > 0) path += "?" + string.Join("&", qs);
+        return await GetJsonAsync(path);
+    }
+
+    public async Task<JsonElement> SetPreferenceAsync(string key, string value, string? type = null, string? sharedName = null)
+    {
+        var body = new Dictionary<string, object?> { ["value"] = value };
+        if (!string.IsNullOrEmpty(type)) body["type"] = type;
+        if (!string.IsNullOrEmpty(sharedName)) body["sharedName"] = sharedName;
+        var json = JsonSerializer.Serialize(body);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync($"{_baseUrl}/api/preferences/{Uri.EscapeDataString(key)}", content);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+    }
+
+    public async Task<JsonElement> DeletePreferenceAsync(string key, string? sharedName = null)
+    {
+        var path = $"/api/preferences/{Uri.EscapeDataString(key)}";
+        if (!string.IsNullOrEmpty(sharedName))
+            path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
+        var response = await _http.DeleteAsync($"{_baseUrl}{path}");
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+    }
+
+    public async Task<bool> ClearPreferencesAsync(string? sharedName = null)
+    {
+        var path = "/api/preferences/clear";
+        if (!string.IsNullOrEmpty(sharedName))
+            path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
+        return await PostActionAsync(path, new { });
+    }
+
+    // ── Secure Storage ──
+
+    public async Task<JsonElement> GetSecureStorageAsync(string key)
+    {
+        return await GetJsonAsync($"/api/secure-storage/{Uri.EscapeDataString(key)}");
+    }
+
+    public async Task<JsonElement> SetSecureStorageAsync(string key, string value)
+    {
+        var json = JsonSerializer.Serialize(new { value });
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync($"{_baseUrl}/api/secure-storage/{Uri.EscapeDataString(key)}", content);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+    }
+
+    public async Task<JsonElement> DeleteSecureStorageAsync(string key)
+    {
+        var response = await _http.DeleteAsync($"{_baseUrl}/api/secure-storage/{Uri.EscapeDataString(key)}");
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+    }
+
+    public async Task<bool> ClearSecureStorageAsync()
+    {
+        return await PostActionAsync("/api/secure-storage/clear", new { });
+    }
+
+    // ── Platform info ──
+
+    public async Task<JsonElement> GetPlatformInfoAsync(string endpoint)
+    {
+        return await GetJsonAsync($"/api/platform/{endpoint}");
+    }
+
+    public async Task<JsonElement> GetGeolocationAsync(string? accuracy = null, int? timeoutSeconds = null)
+    {
+        var path = "/api/platform/geolocation";
+        var qs = new List<string>();
+        if (!string.IsNullOrEmpty(accuracy)) qs.Add($"accuracy={Uri.EscapeDataString(accuracy)}");
+        if (timeoutSeconds.HasValue) qs.Add($"timeout={timeoutSeconds.Value}");
+        if (qs.Count > 0) path += "?" + string.Join("&", qs);
+        return await GetJsonAsync(path);
+    }
+
+    // ── Sensors ──
+
+    public async Task<JsonElement> GetSensorsAsync()
+    {
+        return await GetJsonAsync("/api/sensors");
+    }
+
+    public async Task<bool> StartSensorAsync(string sensor, string? speed = null)
+    {
+        var path = $"/api/sensors/{Uri.EscapeDataString(sensor)}/start";
+        if (!string.IsNullOrEmpty(speed))
+            path += $"?speed={Uri.EscapeDataString(speed)}";
+        return await PostActionAsync(path, new { });
+    }
+
+    public async Task<bool> StopSensorAsync(string sensor)
+    {
+        return await PostActionAsync($"/api/sensors/{Uri.EscapeDataString(sensor)}/stop", new { });
+    }
+
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/MauiDevFlow.Driver/AgentClient.cs
+++ b/src/MauiDevFlow.Driver/AgentClient.cs
@@ -180,6 +180,52 @@ public class AgentClient : IDisposable
     }
 
     /// <summary>
+    /// Set a property value on an element.
+    /// </summary>
+    public async Task<bool> SetPropertyAsync(string elementId, string propertyName, string value)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(new { value });
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await _http.PostAsync($"{_baseUrl}/api/property/{elementId}/{propertyName}", content);
+            return response.IsSuccessStatusCode;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>
+    /// Retrieve application logs from the agent.
+    /// </summary>
+    public async Task<string> GetLogsAsync(int limit = 100, int skip = 0, string? source = null)
+    {
+        var path = $"/api/logs?limit={limit}&skip={skip}";
+        if (!string.IsNullOrEmpty(source) && source != "all")
+            path += $"&source={Uri.EscapeDataString(source)}";
+        return await _http.GetStringAsync($"{_baseUrl}{path}");
+    }
+
+    /// <summary>
+    /// Send a CDP command to a Blazor WebView.
+    /// </summary>
+    public async Task<JsonElement> SendCdpCommandAsync(string method, JsonElement? @params = null, string? webviewId = null)
+    {
+        var path = "/api/cdp";
+        if (!string.IsNullOrEmpty(webviewId))
+            path += $"?webview={Uri.EscapeDataString(webviewId)}";
+
+        var body = new Dictionary<string, object> { ["method"] = method };
+        if (@params.HasValue && @params.Value.ValueKind != JsonValueKind.Undefined)
+            body["params"] = @params.Value;
+
+        var json = JsonSerializer.Serialize(body);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync($"{_baseUrl}{path}", content);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+    }
+
+    /// <summary>
     /// Gets the list of CDP WebViews registered with the agent.
     /// </summary>
     public async Task<JsonElement> GetCdpWebViewsAsync()


### PR DESCRIPTION
Add 'maui-devflow mcp-serve' command that starts an MCP (Model Context
Protocol) server over stdio. This enables VS Code Copilot Chat and other
MCP-compatible AI hosts to interact with running MAUI apps through
structured, typed tool responses — including inline screenshots.

