### PR TITLE
Fix preferences listing crash with non-string types on Android

### DIFF
--- a/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/MauiDevFlow.Agent.Core/DevFlowAgentService.cs
@@ -3609,10 +3609,8 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             var entries = new List<object>();
             foreach (var key in keys.OrderBy(k => k))
             {
-                var value = sharedName != null
-                    ? Preferences.Get(key, (string?)null, sharedName)
-                    : Preferences.Get(key, (string?)null);
-                entries.Add(new { key, value, sharedName });
+                var (value, type) = ReadPreferenceValue(key, sharedName);
+                entries.Add(new { key, value, type, sharedName });
             }
             return Task.FromResult(HttpResponse.Json(new { keys = entries }));
         }
@@ -3620,6 +3618,76 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         {
             return Task.FromResult(HttpResponse.Error($"Failed to list preferences: {ex.Message}"));
         }
+    }
+
+    /// <summary>
+    /// Read a preference value trying all supported types.
+    /// Android SharedPreferences stores typed values and throws ClassCastException
+    /// if you read with the wrong type, so we try each in turn.
+    /// </summary>
+    private (object? Value, string Type) ReadPreferenceValue(string key, string? sharedName)
+    {
+        // Try string first (most common)
+        try
+        {
+            var s = sharedName != null
+                ? Preferences.Get(key, (string?)null, sharedName)
+                : Preferences.Get(key, (string?)null);
+            return (s, "string");
+        }
+        catch { }
+
+        // Try int
+        try
+        {
+            var i = sharedName != null
+                ? Preferences.Get(key, int.MinValue, sharedName)
+                : Preferences.Get(key, int.MinValue);
+            return (i, "int");
+        }
+        catch { }
+
+        // Try bool
+        try
+        {
+            var b = sharedName != null
+                ? Preferences.Get(key, false, sharedName)
+                : Preferences.Get(key, false);
+            return (b, "bool");
+        }
+        catch { }
+
+        // Try double
+        try
+        {
+            var d = sharedName != null
+                ? Preferences.Get(key, double.NaN, sharedName)
+                : Preferences.Get(key, double.NaN);
+            if (!double.IsNaN(d)) return (d, "double");
+        }
+        catch { }
+
+        // Try long
+        try
+        {
+            var l = sharedName != null
+                ? Preferences.Get(key, long.MinValue, sharedName)
+                : Preferences.Get(key, long.MinValue);
+            return (l, "long");
+        }
+        catch { }
+
+        // Try float
+        try
+        {
+            var f = sharedName != null
+                ? Preferences.Get(key, float.NaN, sharedName)
+                : Preferences.Get(key, float.NaN);
+            if (!float.IsNaN(f)) return (f, "float");
+        }
+        catch { }
+
+        return (null, "unknown");
     }
 
     private Task<HttpResponse> HandlePreferencesGet(HttpRequest request)
@@ -3630,18 +3698,28 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                 return Task.FromResult(HttpResponse.Error("key is required"));
 
             request.QueryParams.TryGetValue("sharedName", out var sharedName);
-            var type = request.QueryParams.GetValueOrDefault("type", "string");
+            var requestedType = request.QueryParams.GetValueOrDefault("type", null);
 
-            object? value = type.ToLowerInvariant() switch
+            object? value;
+            string type;
+            if (requestedType != null)
             {
-                "int" or "integer" => sharedName != null ? Preferences.Get(key, 0, sharedName) : Preferences.Get(key, 0),
-                "bool" or "boolean" => sharedName != null ? Preferences.Get(key, false, sharedName) : Preferences.Get(key, false),
-                "double" => sharedName != null ? Preferences.Get(key, 0.0, sharedName) : Preferences.Get(key, 0.0),
-                "float" => sharedName != null ? Preferences.Get(key, 0f, sharedName) : Preferences.Get(key, 0f),
-                "long" => sharedName != null ? Preferences.Get(key, 0L, sharedName) : Preferences.Get(key, 0L),
-                "datetime" => sharedName != null ? Preferences.Get(key, DateTime.MinValue, sharedName) : Preferences.Get(key, DateTime.MinValue),
-                _ => sharedName != null ? Preferences.Get(key, (string?)null, sharedName) : Preferences.Get(key, (string?)null),
-            };
+                type = requestedType;
+                value = type.ToLowerInvariant() switch
+                {
+                    "int" or "integer" => sharedName != null ? Preferences.Get(key, 0, sharedName) : Preferences.Get(key, 0),
+                    "bool" or "boolean" => sharedName != null ? Preferences.Get(key, false, sharedName) : Preferences.Get(key, false),
+                    "double" => sharedName != null ? Preferences.Get(key, 0.0, sharedName) : Preferences.Get(key, 0.0),
+                    "float" => sharedName != null ? Preferences.Get(key, 0f, sharedName) : Preferences.Get(key, 0f),
+                    "long" => sharedName != null ? Preferences.Get(key, 0L, sharedName) : Preferences.Get(key, 0L),
+                    "datetime" => sharedName != null ? Preferences.Get(key, DateTime.MinValue, sharedName) : Preferences.Get(key, DateTime.MinValue),
+                    _ => sharedName != null ? Preferences.Get(key, (string?)null, sharedName) : Preferences.Get(key, (string?)null),
+                };
+            }
+            else
+            {
+                (value, type) = ReadPreferenceValue(key, sharedName);
+            }
 
             var exists = sharedName != null ? Preferences.ContainsKey(key, sharedName) : Preferences.ContainsKey(key);
             return Task.FromResult(HttpResponse.Json(new { key, value, type, exists, sharedName }));


### PR DESCRIPTION
Fixes #39

Android's `SharedPreferences` stores typed values natively and throws `ClassCastException` when you try to read an `int` as a `string`.

### Changes

- Added `ReadPreferenceValue(key, sharedName)` helper that tries each supported type in order (string → int → bool → double → long → float), catching cast failures
- **List handler** uses the helper for each key, so one non-string value no longer crashes the entire listing
- **Get handler** uses the helper when no `type` query param is specified (auto-detect)
- List response now includes a `type` field for each entry

### Testing

Tested by storing an int preference on Android via `POST /api/preferences/myInt` with `{"value": 42, "type": "int"}`, then verifying `GET /api/preferences` returns all preferences including the int with `type: "int"`.